### PR TITLE
Distinguish logical operators from other operators

### DIFF
--- a/Syntaxes/Lua.plist
+++ b/Syntaxes/Lua.plist
@@ -276,7 +276,7 @@
         <key>match</key>
         <string>\b(and|or|not|\|\||\&amp;\&amp;|\!)\b</string>
         <key>name</key>
-        <string>keyword.operator.lua</string>
+        <string>keyword.operator.logical.lua</string>
       </dict>
       <dict>
         <key>match</key>


### PR DESCRIPTION
This makes syntax highlighting themes able to color the `and`/`or`/ `not` keywords correctly.
