### PR TITLE
LDoc and LuaDoc support

### DIFF
--- a/Syntaxes/Lua.plist
+++ b/Syntaxes/Lua.plist
@@ -597,12 +597,16 @@
                 <key>end</key>
                 <string>\n</string>
                 <key>name</key>
-                <string>comment.line.double-dash.doc.lua</string>
+                <string>comment.line.double-dash.documentation.lua</string>
                 <key>patterns</key>
                 <array>
                   <dict>
                     <key>include</key>
                     <string>#emmydoc</string>
+                  </dict>
+                  <dict>
+                    <key>include</key>
+                    <string>#ldoc_tag</string>
                   </dict>
                 </array>
               </dict>
@@ -621,6 +625,13 @@
                 <string>\n</string>
                 <key>name</key>
                 <string>comment.line.double-dash.lua</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>#ldoc_tag</string>
+                  </dict>
+                </array>
               </dict>
             </array>
           </dict>
@@ -1374,6 +1385,26 @@
             </array>
           </dict>
         </array>
+      </dict>
+      <key>ldoc_tag</key>
+      <dict>
+        <key>match</key>
+        <string>\G\s*(@)(alias|annotation|author|charset|class|classmod|comment|constructor|copyright|description|example|export|factory|field|file|fixme|function|include|lfunction|license|local|module|name|param|pragma|private|raise|release|return|script|section|see|set|static|submodule|summary|table|todo|topic|type|usage|warning|within)\b</string>
+        <key>end</key>
+        <string>(?!@)\b</string>
+        <key>captures</key>
+        <dict>
+          <key>1</key>
+          <dict>
+            <key>name</key>
+            <string>punctuation.definition.block.tag.ldoc</string>
+          </dict>
+          <key>2</key>
+          <dict>
+            <key>name</key>
+            <string>storage.type.class.ldoc</string>
+          </dict>
+        </dict>
       </dict>
     </dict>
   </dict>

--- a/Syntaxes/Lua.plist
+++ b/Syntaxes/Lua.plist
@@ -721,7 +721,7 @@
         <array>
           <dict>
             <key>begin</key>
-            <string>(?&lt;=---\s*)@class</string>
+            <string>(?&lt;=---[ \t]*)@class</string>
             <key>beginCaptures</key>
             <dict>
               <key>0</key>
@@ -750,7 +750,7 @@
           </dict>
           <dict>
             <key>begin</key>
-            <string>(?&lt;=---\s*)@enum</string>
+            <string>(?&lt;=---[ \t]*)@enum</string>
             <key>beginCaptures</key>
             <dict>
               <key>0</key>
@@ -781,7 +781,7 @@
           </dict>
           <dict>
             <key>begin</key>
-            <string>(?&lt;=---\s*)@type</string>
+            <string>(?&lt;=---[ \t]*)@type</string>
             <key>beginCaptures</key>
             <dict>
               <key>0</key>
@@ -802,7 +802,7 @@
           </dict>
           <dict>
             <key>begin</key>
-            <string>(?&lt;=---\s*)@alias</string>
+            <string>(?&lt;=---[ \t]*)@alias</string>
             <key>beginCaptures</key>
             <dict>
               <key>0</key>
@@ -840,7 +840,7 @@
           </dict>
           <dict>
             <key>begin</key>
-            <string>(?&lt;=---\s*)(@operator)\s*(\b[a-z]+)?</string>
+            <string>(?&lt;=---[ \t]*)(@operator)\s*(\b[a-z]+)?</string>
             <key>beginCaptures</key>
             <dict>
               <key>1</key>
@@ -866,7 +866,7 @@
           </dict>
           <dict>
             <key>begin</key>
-            <string>(?&lt;=---\s*)@cast</string>
+            <string>(?&lt;=---[ \t]*)@cast</string>
             <key>beginCaptures</key>
             <dict>
               <key>0</key>
@@ -910,7 +910,7 @@
           </dict>
           <dict>
             <key>begin</key>
-            <string>(?&lt;=---\s*)@param</string>
+            <string>(?&lt;=---[ \t]*)@param</string>
             <key>beginCaptures</key>
             <dict>
               <key>0</key>
@@ -953,7 +953,7 @@
           </dict>
           <dict>
             <key>begin</key>
-            <string>(?&lt;=---\s*)@return</string>
+            <string>(?&lt;=---[ \t]*)@return</string>
             <key>beginCaptures</key>
             <dict>
               <key>0</key>
@@ -980,7 +980,7 @@
           </dict>
           <dict>
             <key>begin</key>
-            <string>(?&lt;=---\s*)@field</string>
+            <string>(?&lt;=---[ \t]*)@field</string>
             <key>beginCaptures</key>
             <dict>
               <key>0</key>
@@ -1033,7 +1033,7 @@
           </dict>
           <dict>
             <key>begin</key>
-            <string>(?&lt;=---\s*)@generic</string>
+            <string>(?&lt;=---[ \t]*)@generic</string>
             <key>beginCaptures</key>
             <dict>
               <key>0</key>
@@ -1085,7 +1085,7 @@
           </dict>
           <dict>
             <key>begin</key>
-            <string>(?&lt;=---\s*)@vararg</string>
+            <string>(?&lt;=---[ \t]*)@vararg</string>
             <key>beginCaptures</key>
             <dict>
               <key>0</key>
@@ -1106,7 +1106,7 @@
           </dict>
           <dict>
             <key>begin</key>
-            <string>(?&lt;=---\s*)@overload</string>
+            <string>(?&lt;=---[ \t]*)@overload</string>
             <key>beginCaptures</key>
             <dict>
               <key>0</key>
@@ -1127,7 +1127,7 @@
           </dict>
           <dict>
             <key>begin</key>
-            <string>(?&lt;=---\s*)@deprecated</string>
+            <string>(?&lt;=---[ \t]*)@deprecated</string>
             <key>beginCaptures</key>
             <dict>
               <key>0</key>
@@ -1141,7 +1141,7 @@
           </dict>
           <dict>
             <key>begin</key>
-            <string>(?&lt;=---\s*)@meta</string>
+            <string>(?&lt;=---[ \t]*)@meta</string>
             <key>beginCaptures</key>
             <dict>
               <key>0</key>
@@ -1155,7 +1155,7 @@
           </dict>
           <dict>
             <key>begin</key>
-            <string>(?&lt;=---\s*)@private</string>
+            <string>(?&lt;=---[ \t]*)@private</string>
             <key>beginCaptures</key>
             <dict>
               <key>0</key>
@@ -1169,7 +1169,7 @@
           </dict>
           <dict>
             <key>begin</key>
-            <string>(?&lt;=---\s*)@protected</string>
+            <string>(?&lt;=---[ \t]*)@protected</string>
             <key>beginCaptures</key>
             <dict>
               <key>0</key>
@@ -1183,7 +1183,7 @@
           </dict>
           <dict>
             <key>begin</key>
-            <string>(?&lt;=---\s*)@package</string>
+            <string>(?&lt;=---[ \t]*)@package</string>
             <key>beginCaptures</key>
             <dict>
               <key>0</key>
@@ -1197,7 +1197,7 @@
           </dict>
           <dict>
             <key>begin</key>
-            <string>(?&lt;=---\s*)@version</string>
+            <string>(?&lt;=---[ \t]*)@version</string>
             <key>beginCaptures</key>
             <dict>
               <key>0</key>
@@ -1226,7 +1226,7 @@
           </dict>
           <dict>
             <key>begin</key>
-            <string>(?&lt;=---\s*)@see</string>
+            <string>(?&lt;=---[ \t]*)@see</string>
             <key>beginCaptures</key>
             <dict>
               <key>0</key>
@@ -1255,7 +1255,7 @@
           </dict>
           <dict>
             <key>begin</key>
-            <string>(?&lt;=---\s*)@diagnostic</string>
+            <string>(?&lt;=---[ \t]*)@diagnostic</string>
             <key>beginCaptures</key>
             <dict>
               <key>0</key>
@@ -1306,7 +1306,7 @@
           </dict>
           <dict>
             <key>begin</key>
-            <string>(?&lt;=---\s*)@module</string>
+            <string>(?&lt;=---[ \t]*)@module</string>
             <key>beginCaptures</key>
             <dict>
               <key>0</key>
@@ -1327,7 +1327,7 @@
           </dict>
           <dict>
             <key>match</key>
-            <string>(?&lt;=---\s*)@(async|nodiscard)</string>
+            <string>(?&lt;=---[ \t]*)@(async|nodiscard)</string>
             <key>name</key>
             <string>storage.type.annotation.lua</string>
           </dict>
@@ -1443,7 +1443,7 @@
       <key>ldoc_tag</key>
       <dict>
         <key>match</key>
-        <string>\G\s*(@)(alias|annotation|author|charset|class|classmod|comment|constructor|copyright|description|example|export|factory|field|file|fixme|function|include|lfunction|license|local|module|name|param|pragma|private|raise|release|return|script|section|see|set|static|submodule|summary|table|todo|topic|type|usage|warning|within)\b</string>
+        <string>\G[ \t]*(@)(alias|annotation|author|charset|class|classmod|comment|constructor|copyright|description|example|export|factory|field|file|fixme|function|include|lfunction|license|local|module|name|param|pragma|private|raise|release|return|script|section|see|set|static|submodule|summary|tfield|thread|tparam|treturn|todo|topic|type|usage|warning|within)\b</string>
         <key>end</key>
         <string>(?!@)\b</string>
         <key>captures</key>

--- a/Syntaxes/Lua.plist
+++ b/Syntaxes/Lua.plist
@@ -1463,7 +1463,7 @@
       <key>ldoc_summary</key>
       <dict>
         <key>begin</key>
-        <string>\G(?!\s*@\w+)</string>
+        <string>\G ?(?!@\w+| )</string>
         <key>beginCaptures</key>
         <dict>
           <key>0</key>

--- a/Syntaxes/Lua.plist
+++ b/Syntaxes/Lua.plist
@@ -92,7 +92,7 @@
                 <array>
                   <dict>
                     <key>include</key>
-                    <string>#luadoc.type</string>
+                    <string>#emmydoc.type</string>
                   </dict>
                 </array>
               </dict>
@@ -602,7 +602,7 @@
                 <array>
                   <dict>
                     <key>include</key>
-                    <string>#luadoc</string>
+                    <string>#emmydoc</string>
                   </dict>
                 </array>
               </dict>
@@ -650,7 +650,7 @@
           </dict>
         </array>
       </dict>
-      <key>luadoc</key>
+      <key>emmydoc</key>
       <dict>
         <key>patterns</key>
         <array>
@@ -731,7 +731,7 @@
             <array>
               <dict>
                 <key>include</key>
-                <string>#luadoc.type</string>
+                <string>#emmydoc.type</string>
               </dict>
             </array>
           </dict>
@@ -767,7 +767,7 @@
                 <array>
                   <dict>
                     <key>include</key>
-                    <string>#luadoc.type</string>
+                    <string>#emmydoc.type</string>
                   </dict>
                 </array>
               </dict>
@@ -795,7 +795,7 @@
             <array>
               <dict>
                 <key>include</key>
-                <string>#luadoc.type</string>
+                <string>#emmydoc.type</string>
               </dict>
             </array>
           </dict>
@@ -831,7 +831,7 @@
                 <array>
                   <dict>
                     <key>include</key>
-                    <string>#luadoc.type</string>
+                    <string>#emmydoc.type</string>
                   </dict>
                   <dict>
                     <key>match</key>
@@ -880,7 +880,7 @@
                 <array>
                   <dict>
                     <key>include</key>
-                    <string>#luadoc.type</string>
+                    <string>#emmydoc.type</string>
                   </dict>
                 </array>
               </dict>
@@ -909,7 +909,7 @@
               </dict>
               <dict>
                 <key>include</key>
-                <string>#luadoc.type</string>
+                <string>#emmydoc.type</string>
               </dict>
             </array>
           </dict>
@@ -954,7 +954,7 @@
                   </dict>
                   <dict>
                     <key>include</key>
-                    <string>#luadoc.type</string>
+                    <string>#emmydoc.type</string>
                   </dict>
                   <dict>
                     <key>match</key>
@@ -1012,7 +1012,7 @@
                   </dict>
                   <dict>
                     <key>include</key>
-                    <string>#luadoc.type</string>
+                    <string>#emmydoc.type</string>
                   </dict>
                 </array>
               </dict>
@@ -1035,7 +1035,7 @@
             <array>
               <dict>
                 <key>include</key>
-                <string>#luadoc.type</string>
+                <string>#emmydoc.type</string>
               </dict>
             </array>
           </dict>
@@ -1056,7 +1056,7 @@
             <array>
               <dict>
                 <key>include</key>
-                <string>#luadoc.type</string>
+                <string>#emmydoc.type</string>
               </dict>
             </array>
           </dict>
@@ -1289,7 +1289,7 @@
           </dict>
         </array>
       </dict>
-      <key>luadoc.type</key>
+      <key>emmydoc.type</key>
       <dict>
         <key>patterns</key>
         <array>
@@ -1322,7 +1322,7 @@
               </dict>
               <dict>
                 <key>include</key>
-                <string>#luadoc.type</string>
+                <string>#emmydoc.type</string>
               </dict>
               <dict>
                 <key>include</key>

--- a/Syntaxes/Lua.plist
+++ b/Syntaxes/Lua.plist
@@ -566,6 +566,13 @@
                 </dict>
                 <key>name</key>
                 <string>comment.block.lua</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>#comment_documentation_bracket</string>
+                  </dict>
+                </array>
               </dict>
               <dict>
                 <key>begin</key>
@@ -662,6 +669,49 @@
             </dict>
             <key>name</key>
             <string>comment.block.lua</string>
+            <key>patterns</key>
+            <array>
+              <dict>
+                <key>include</key>
+                <string>#comment_documentation_asterisk</string>
+              </dict>
+            </array>
+          </dict>
+        </array>
+      </dict>
+      <key>comment_documentation_asterisk</key>
+      <dict>
+        <key>begin</key>
+        <string>(?&lt;=/\*\*)([^*]|\*(?!/))*$</string>
+        <key> </key>
+        <string>(^|\G)[ \t]*\*(?!/)(?=([^*]|[*](?!/))*$)</string>
+        <key>patterns</key>
+        <array>
+          <dict>
+            <key>include</key>
+            <string>#emmydoc</string>
+          </dict>
+          <dict>
+            <key>include</key>
+            <string>#ldoc_tag</string>
+          </dict>
+        </array>
+      </dict>
+      <key>comment_documentation_bracket</key>
+      <dict>
+        <key>begin</key>
+        <string>(?&lt;=--\[\[)([^-]|\-(?!\]\]))*$</string>
+        <key>while</key>
+        <string>(^|\G)[ \t]*-*(?!\]\])(?=([^-]|[-](?!\]\]))*$)</string>
+        <key>patterns</key>
+        <array>
+          <dict>
+            <key>include</key>
+            <string>#emmydoc</string>
+          </dict>
+          <dict>
+            <key>include</key>
+            <string>#ldoc_tag</string>
           </dict>
         </array>
       </dict>

--- a/Syntaxes/Lua.plist
+++ b/Syntaxes/Lua.plist
@@ -606,6 +606,10 @@
                   </dict>
                   <dict>
                     <key>include</key>
+                    <string>#ldoc_summary</string>
+                  </dict>
+                  <dict>
+                    <key>include</key>
                     <string>#ldoc_tag</string>
                   </dict>
                 </array>
@@ -1405,6 +1409,23 @@
             <string>storage.type.class.ldoc</string>
           </dict>
         </dict>
+      </dict>
+      <key>ldoc_summary</key>
+      <dict>
+        <key>begin</key>
+        <string>\G(?!\s*@\w+)</string>
+        <key>beginCaptures</key>
+        <dict>
+          <key>0</key>
+          <dict>
+            <key>name</key>
+            <string>punctuation.definition.comment.lua</string>
+          </dict>
+        </dict>
+        <key>end</key>
+        <string>$</string>
+        <key>name</key>
+        <string>entity.name.section.ldoc</string>
       </dict>
     </dict>
   </dict>

--- a/lua.tmLanguage.json
+++ b/lua.tmLanguage.json
@@ -1,900 +1,967 @@
 {
-	"name": "Lua",
-	"scopeName": "source.lua",
-	"patterns": [
-		{
-			"begin": "\\b(?:(local)\\s+)?(function)\\b(?![,:])",
-			"beginCaptures": {
-				"1": {
-					"name": "keyword.local.lua"
-				},
-				"2": {
-					"name": "keyword.control.lua"
-				}
-			},
-			"end": "(?<=[\\)\\-{}\\[\\]\"'])",
-			"name": "meta.function.lua",
-			"patterns": [
-				{
-					"include": "#comment"
-				},
-				{
-					"begin": "(\\()",
-					"beginCaptures": {
-						"1": {
-							"name": "punctuation.definition.parameters.begin.lua"
-						}
-					},
-					"end": "(\\))|(?=[\\-\\.{}\\[\\]\"'])",
-					"endCaptures": {
-						"1": {
-							"name": "punctuation.definition.parameters.finish.lua"
-						}
-					},
-					"name": "meta.parameter.lua",
-					"patterns": [
-						{
-							"include": "#comment"
-						},
-						{
-							"match": "[a-zA-Z_][a-zA-Z0-9_]*",
-							"name": "variable.parameter.function.lua"
-						},
-						{
-							"match": ",",
-							"name": "punctuation.separator.arguments.lua"
-						},
-						{
-							"begin": ":",
-							"beginCaptures": {
-								"0": {
-									"name": "punctuation.separator.arguments.lua"
-								}
-							},
-							"end": "(?=[\\),])",
-							"patterns": [
-								{
-									"include": "#luadoc.type"
-								}
-							]
-						}
-					]
-				},
-				{
-					"match": "\\b([a-zA-Z_][a-zA-Z0-9_]*)\\b\\s*(?=:)",
-					"name": "entity.name.class.lua"
-				},
-				{
-					"match": "\\b([a-zA-Z_][a-zA-Z0-9_]*)\\b",
-					"name": "entity.name.function.lua"
-				}
-			]
-		},
-		{
-			"match": "(?<![\\w\\d.])0[xX][0-9A-Fa-f]+(\\.[0-9A-Fa-f]*)?([eE]-?\\d*)?([pP][-+]\\d+)?",
-			"name": "constant.numeric.float.hexadecimal.lua"
-		},
-		{
-			"match": "(?<![\\w\\d.])0[xX]\\.[0-9A-Fa-f]+([eE]-?\\d*)?([pP][-+]\\d+)?",
-			"name": "constant.numeric.float.hexadecimal.lua"
-		},
-		{
-			"match": "(?<![\\w\\d.])0[xX][0-9A-Fa-f]+(?![pPeE.0-9])",
-			"name": "constant.numeric.integer.hexadecimal.lua"
-		},
-		{
-			"match": "(?<![\\w\\d.])\\d+(\\.\\d*)?([eE]-?\\d*)?",
-			"name": "constant.numeric.float.lua"
-		},
-		{
-			"match": "(?<![\\w\\d.])\\.\\d+([eE]-?\\d*)?",
-			"name": "constant.numeric.float.lua"
-		},
-		{
-			"match": "(?<![\\w\\d.])\\d+(?![pPeE.0-9])",
-			"name": "constant.numeric.integer.lua"
-		},
-		{
-			"include": "#string"
-		},
-		{
-			"captures": {
-				"1": {
-					"name": "punctuation.definition.comment.lua"
-				}
-			},
-			"match": "\\A(#!).*$\\n?",
-			"name": "comment.line.shebang.lua"
-		},
-		{
-			"include": "#comment"
-		},
-		{
-			"captures": {
-				"1": {
-					"name": "keyword.control.goto.lua"
-				},
-				"2": {
-					"name": "string.tag.lua"
-				}
-			},
-			"match": "\\b(goto)\\s+([a-zA-Z_][a-zA-Z0-9_]*)"
-		},
-		{
-			"captures": {
-				"1": {
-					"name": "punctuation.section.embedded.begin.lua"
-				},
-				"2": {
-					"name": "punctuation.section.embedded.end.lua"
-				}
-			},
-			"match": "(::)\\s*[a-zA-Z_][a-zA-Z0-9_]*\\s*(::)",
-			"name": "string.tag.lua"
-		},
-		{
-			"match": "<\\s*(const|close)\\s*>",
-			"captures": {
-				"1": {
-					"name": "string.tag.lua"
-				}
-			}
-		},
-		{
-			"match": "\\<[a-zA-Z_\\*][a-zA-Z0-9_\\.\\*\\-]*\\>",
-			"name": "storage.type.generic.lua"
-		},
-		{
-			"match": "\\b(break|do|else|for|if|elseif|goto|return|then|repeat|while|until|end|in)\\b",
-			"name": "keyword.control.lua"
-		},
-		{
-			"match": "\\b(local|global)\\b",
-			"name": "keyword.local.lua"
-		},
-		{
-			"match": "\\b(function)\\b(?![,:])",
-			"name": "keyword.control.lua"
-		},
-		{
-			"match": "(?<![^.]\\.|:)\\b(false|nil(?!:)|true|_ENV|_G|_VERSION|math\\.(pi|huge|maxinteger|mininteger)|utf8\\.charpattern|io\\.(stdin|stdout|stderr)|package\\.(config|cpath|loaded|loaders|path|preload|searchers))\\b|(?<![.])\\.{3}(?!\\.)",
-			"name": "constant.language.lua"
-		},
-		{
-			"match": "(?<![^.]\\.|:)\\b(self)\\b",
-			"name": "variable.language.self.lua"
-		},
-		{
-			"match": "(?<![^.]\\.|:)\\b(assert|collectgarbage|dofile|error|getfenv|getmetatable|ipairs|load|loadfile|loadstring|module|next|pairs|pcall|print|rawequal|rawget|rawlen|rawset|require|select|setfenv|setmetatable|tonumber|tostring|type|unpack|xpcall)\\b(?!\\s*=(?!=))",
-			"name": "support.function.lua"
-		},
-		{
-			"match": "(?<![^.]\\.|:)\\b(async)\\b(?!\\s*=(?!=))",
-			"name": "entity.name.tag.lua"
-		},
-		{
-			"match": "(?<![^.]\\.|:)\\b(coroutine\\.(create|isyieldable|close|resume|running|status|wrap|yield)|string\\.(byte|char|dump|find|format|gmatch|gsub|len|lower|match|pack|packsize|rep|reverse|sub|unpack|upper)|table\\.(concat|insert|maxn|move|pack|remove|sort|unpack)|math\\.(abs|acos|asin|atan2?|ceil|cosh?|deg|exp|floor|fmod|frexp|ldexp|log|log10|max|min|modf|pow|rad|random|randomseed|sinh?|sqrt|tanh?|tointeger|type)|io\\.(close|flush|input|lines|open|output|popen|read|tmpfile|type|write)|os\\.(clock|date|difftime|execute|exit|getenv|remove|rename|setlocale|time|tmpname)|package\\.(loadlib|seeall|searchpath)|debug\\.(debug|[gs]etfenv|[gs]ethook|getinfo|[gs]etlocal|[gs]etmetatable|getregistry|[gs]etupvalue|[gs]etuservalue|set[Cc]stacklimit|traceback|upvalueid|upvaluejoin)|bit32\\.(arshift|band|bnot|bor|btest|bxor|extract|replace|lrotate|lshift|rrotate|rshift)|utf8\\.(char|codes|codepoint|len|offset))\\b(?!\\s*=(?!=))",
-			"name": "support.function.library.lua"
-		},
-		{
-			"match": "\\b(and|or|not|\\|\\||\\&\\&|\\!)\\b",
-			"name": "keyword.operator.lua"
-		},
-		{
-			"match": "\\b([a-zA-Z_][a-zA-Z0-9_]*)\\b(?=\\s*(?:[({\"']|\\[\\[))",
-			"name": "support.function.any-method.lua"
-		},
-		{
-			"match": "\\b([a-zA-Z_][a-zA-Z0-9_]*)\\b(?=\\s*\\??:)",
-			"name": "entity.name.class.lua"
-		},
-		{
-			"match": "(?<=[^.]\\.|:)\\b([a-zA-Z_][a-zA-Z0-9_]*)\\b(?!\\s*=\\s*\\b(function)\\b)",
-			"name": "entity.other.attribute.lua"
-		},
-		{
-			"match": "\\b([a-zA-Z_][a-zA-Z0-9_]*)\\b(?!\\s*=\\s*\\b(function)\\b)",
-			"name": "variable.other.lua"
-		},
-		{
-			"match": "\\b([a-zA-Z_][a-zA-Z0-9_]*)\\b(?=\\s*=\\s*\\b(function)\\b)",
-			"name": "entity.name.function.lua"
-		},
-		{
-			"match": "\\+|-|%|#|\\*|\\/|\\^|==?|~=|!=|<=?|>=?|(?<!\\.)\\.{2}(?!\\.)",
-			"name": "keyword.operator.lua"
-		}
-	],
-	"repository": {
-		"escaped_char": {
-			"patterns": [
-				{
-					"match": "\\\\[abfnrtv\\\\\"'\\n]",
-					"name": "constant.character.escape.lua"
-				},
-				{
-					"match": "\\\\z[\\n\\t ]*",
-					"name": "constant.character.escape.lua"
-				},
-				{
-					"match": "\\\\\\d{1,3}",
-					"name": "constant.character.escape.byte.lua"
-				},
-				{
-					"match": "\\\\x[0-9A-Fa-f][0-9A-Fa-f]",
-					"name": "constant.character.escape.byte.lua"
-				},
-				{
-					"match": "\\\\u\\{[0-9A-Fa-f]+\\}",
-					"name": "constant.character.escape.unicode.lua"
-				},
-				{
-					"match": "\\\\.",
-					"name": "invalid.illegal.character.escape.lua"
-				}
-			]
-		},
-		"string": {
-			"patterns": [
-				{
-					"begin": "'",
-					"beginCaptures": {
-						"0": {
-							"name": "punctuation.definition.string.begin.lua"
-						}
-					},
-					"end": "'[ \\t]*|(?=\\n)",
-					"endCaptures": {
-						"0": {
-							"name": "punctuation.definition.string.end.lua"
-						}
-					},
-					"name": "string.quoted.single.lua",
-					"patterns": [
-						{
-							"include": "#escaped_char"
-						}
-					]
-				},
-				{
-					"begin": "\"",
-					"beginCaptures": {
-						"0": {
-							"name": "punctuation.definition.string.begin.lua"
-						}
-					},
-					"end": "\"[ \\t]*|(?=\\n)",
-					"endCaptures": {
-						"0": {
-							"name": "punctuation.definition.string.end.lua"
-						}
-					},
-					"name": "string.quoted.double.lua",
-					"patterns": [
-						{
-							"include": "#escaped_char"
-						}
-					]
-				},
-				{
-					"begin": "`",
-					"beginCaptures": {
-						"0": {
-							"name": "punctuation.definition.string.begin.lua"
-						}
-					},
-					"end": "`[ \\t]*|(?=\\n)",
-					"endCaptures": {
-						"0": {
-							"name": "punctuation.definition.string.end.lua"
-						}
-					},
-					"name": "string.quoted.double.lua"
-				},
-				{
-					"begin": "(?<=\\.cdef)\\s*(\\[(=*)\\[)",
-					"beginCaptures": {
-						"0": {
-							"name": "string.quoted.other.multiline.lua"
-						},
-						"1": {
-							"name": "punctuation.definition.string.begin.lua"
-						}
-					},
-					"contentName": "meta.embedded.lua",
-					"end": "(\\]\\2\\])[ \\t]*",
-					"endCaptures": {
-						"0": {
-							"name": "string.quoted.other.multiline.lua"
-						},
-						"1": {
-							"name": "punctuation.definition.string.end.lua"
-						}
-					},
-					"patterns": [
-						{
-							"include": "source.c"
-						}
-					]
-				},
-				{
-					"begin": "(?<!--)\\[(=*)\\[",
-					"beginCaptures": {
-						"0": {
-							"name": "punctuation.definition.string.begin.lua"
-						}
-					},
-					"end": "\\]\\1\\][ \\t]*",
-					"endCaptures": {
-						"0": {
-							"name": "punctuation.definition.string.end.lua"
-						}
-					},
-					"name": "string.quoted.other.multiline.lua"
-				}
-			]
-		},
-		"comment": {
-			"patterns": [
-				{
-					"begin": "(^[ \\t]+)?(?=--)",
-					"beginCaptures": {
-						"1": {
-							"name": "punctuation.whitespace.comment.leading.lua"
-						}
-					},
-					"end": "(?!\\G)((?!^)[ \\t]+\\n)?",
-					"endCaptures": {
-						"1": {
-							"name": "punctuation.whitespace.comment.trailing.lua"
-						}
-					},
-					"patterns": [
-						{
-							"begin": "--\\[(=*)\\[",
-							"beginCaptures": {
-								"0": {
-									"name": "punctuation.definition.comment.begin.lua"
-								}
-							},
-							"end": "\\]\\1\\]",
-							"endCaptures": {
-								"0": {
-									"name": "punctuation.definition.comment.end.lua"
-								}
-							},
-							"name": "comment.block.lua"
-						},
-						{
-							"begin": "----",
-							"beginCaptures": {
-								"0": {
-									"name": "punctuation.definition.comment.lua"
-								}
-							},
-							"end": "\\n",
-							"name": "comment.line.double-dash.lua"
-						},
-						{
-							"begin": "---",
-							"beginCaptures": {
-								"0": {
-									"name": "punctuation.definition.comment.lua"
-								}
-							},
-							"end": "\\n",
-							"name": "comment.line.double-dash.doc.lua",
-							"patterns": [
-								{
-									"include": "#luadoc"
-								}
-							]
-						},
-						{
-							"begin": "--",
-							"beginCaptures": {
-								"0": {
-									"name": "punctuation.definition.comment.lua"
-								}
-							},
-							"end": "\\n",
-							"name": "comment.line.double-dash.lua"
-						}
-					]
-				},
-				{
-					"begin": "\\/\\*",
-					"beginCaptures": {
-						"0": {
-							"name": "punctuation.definition.comment.begin.lua"
-						}
-					},
-					"end": "\\*\\/",
-					"endCaptures": {
-						"0": {
-							"name": "punctuation.definition.comment.end.lua"
-						}
-					},
-					"name": "comment.block.lua"
-				}
-			]
-		},
-		"luadoc": {
-			"patterns": [
-				{
-					"begin": "(?<=---\\s*)@class",
-					"beginCaptures": {
-						"0": {
-							"name": "storage.type.annotation.lua"
-						}
-					},
-					"end": "(?=[\\n@#])",
-					"patterns": [
-						{
-							"match": "\\b([a-zA-Z_\\*][a-zA-Z0-9_\\.\\*\\-]*)",
-							"name": "support.class.lua"
-						},
-						{
-							"match": ":|,",
-							"name": "keyword.operator.lua"
-						}
-					]
-				},
-				{
-					"begin": "(?<=---\\s*)@enum",
-					"beginCaptures": {
-						"0": {
-							"name": "storage.type.annotation.lua"
-						}
-					},
-					"end": "(?=[\\n@#])",
-					"patterns": [
-						{
-							"begin": "\\b([a-zA-Z_\\*][a-zA-Z0-9_\\.\\*\\-]*)",
-							"beginCaptures": {
-								"0": {
-									"name": "variable.lua"
-								}
-							},
-							"end": "(?=\\n)"
-						}
-					]
-				},
-				{
-					"begin": "(?<=---\\s*)@type",
-					"beginCaptures": {
-						"0": {
-							"name": "storage.type.annotation.lua"
-						}
-					},
-					"end": "(?=[\\n@#])",
-					"patterns": [
-						{
-							"include": "#luadoc.type"
-						}
-					]
-				},
-				{
-					"begin": "(?<=---\\s*)@alias",
-					"beginCaptures": {
-						"0": {
-							"name": "storage.type.annotation.lua"
-						}
-					},
-					"end": "(?=[\\n@#])",
-					"patterns": [
-						{
-							"begin": "\\b([a-zA-Z_\\*][a-zA-Z0-9_\\.\\*\\-]*)",
-							"beginCaptures": {
-								"0": {
-									"name": "variable.lua"
-								}
-							},
-							"end": "(?=[\\n#])",
-							"patterns": [
-								{
-									"include": "#luadoc.type"
-								}
-							]
-						}
-					]
-				},
-				{
-					"begin": "(?<=---\\s*)(@operator)\\s*(\\b[a-z]+)?",
-					"beginCaptures": {
-						"1": {
-							"name": "storage.type.annotation.lua"
-						},
-						"2":{
-							"name":"support.function.library.lua"
-						}
-					},
-					"end": "(?=[\\n@#])",
-					"patterns": [
-						{
-							"include": "#luadoc.type"
-						}
-					]
-				},
-				{
-					"begin": "(?<=---\\s*)@cast",
-					"beginCaptures": {
-						"0": {
-							"name": "storage.type.annotation.lua"
-						}
-					},
-					"end": "(?=[\\n@#])",
-					"patterns": [
-						{
-							"begin": "\\b([a-zA-Z_\\*][a-zA-Z0-9_\\.\\*\\-]*)",
-							"beginCaptures": {
-								"0": {
-									"name": "variable.other.lua"
-								}
-							},
-							"end": "(?=\\n)",
-							"patterns": [
-								{
-									"include": "#luadoc.type"
-								},
-								{
-									"match": "([+-|])",
-									"name": "keyword.operator.lua"
-								}
-							]
-						}
-					]
-				},
-				{
-					"begin": "(?<=---\\s*)@param",
-					"beginCaptures": {
-						"0": {
-							"name": "storage.type.annotation.lua"
-						}
-					},
-					"end": "(?=[\\n@#])",
-					"patterns": [
-						{
-							"begin": "\\b([a-zA-Z_][a-zA-Z0-9_]*)\\b(\\??)",
-							"beginCaptures": {
-								"1": {
-									"name": "entity.name.variable.lua"
-								},
-								"2": {
-									"name": "keyword.operator.lua"
-								}
-							},
-							"end": "(?=[\\n#])",
-							"patterns": [
-								{
-									"include": "#luadoc.type"
-								}
-							]
-						}
-					]
-				},
-				{
-					"begin": "(?<=---\\s*)@return",
-					"beginCaptures": {
-						"0": {
-							"name": "storage.type.annotation.lua"
-						}
-					},
-					"end": "(?=[\\n@#])",
-					"patterns": [
-						{
-							"match": "\\?",
-							"name": "keyword.operator.lua"
-						},
-						{
-							"include": "#luadoc.type"
-						}
-					]
-				},
-				{
-					"begin": "(?<=---\\s*)@field",
-					"beginCaptures": {
-						"0": {
-							"name": "storage.type.annotation.lua"
-						}
-					},
-					"end": "(?=[\\n@#])",
-					"patterns": [
-						{
-							"begin": "(\\b([a-zA-Z_][a-zA-Z0-9_]*)\\b|(\\[))(\\??)",
-							"beginCaptures": {
-								"2": {
-									"name": "entity.name.variable.lua"
-								},
-								"3": {
-									"name": "keyword.operator.lua"
-								}
-							},
-							"end": "(?=[\\n#])",
-							"patterns": [
-								{
-									"include": "#string"
-								},
-								{
-									"include": "#luadoc.type"
-								},
-								{
-									"match": "\\]",
-									"name": "keyword.operator.lua"
-								}
-							]
-						}
-					]
-				},
-				{
-					"begin": "(?<=---\\s*)@generic",
-					"beginCaptures": {
-						"0": {
-							"name": "storage.type.annotation.lua"
-						}
-					},
-					"end": "(?=[\\n@#])",
-					"patterns": [
-						{
-							"begin": "\\b([a-zA-Z_][a-zA-Z0-9_]*)\\b",
-							"beginCaptures": {
-								"0": {
-									"name": "storage.type.generic.lua"
-								}
-							},
-							"end": "(?=\\n)|(,)",
-							"endCaptures": {
-								"0": {
-									"name": "keyword.operator.lua"
-								}
-							},
-							"patterns": [
-								{
-									"match": ":",
-									"name": "keyword.operator.lua"
-								},
-								{
-									"include": "#luadoc.type"
-								}
-							]
-						}
-					]
-				},
-				{
-					"begin": "(?<=---\\s*)@vararg",
-					"beginCaptures": {
-						"0": {
-							"name": "storage.type.annotation.lua"
-						}
-					},
-					"end": "(?=[\\n@#])",
-					"patterns": [
-						{
-							"include": "#luadoc.type"
-						}
-					]
-				},
-				{
-					"begin": "(?<=---\\s*)@overload",
-					"beginCaptures": {
-						"0": {
-							"name": "storage.type.annotation.lua"
-						}
-					},
-					"end": "(?=[\\n@#])",
-					"patterns": [
-						{
-							"include": "#luadoc.type"
-						}
-					]
-				},
-				{
-					"begin": "(?<=---\\s*)@deprecated",
-					"beginCaptures": {
-						"0": {
-							"name": "storage.type.annotation.lua"
-						}
-					},
-					"end": "(?=[\\n@#])"
-				},
-				{
-					"begin": "(?<=---\\s*)@meta",
-					"beginCaptures": {
-						"0": {
-							"name": "storage.type.annotation.lua"
-						}
-					},
-					"end": "(?=[\\n@#])"
-				},
-				{
-					"begin": "(?<=---\\s*)@private",
-					"beginCaptures": {
-						"0": {
-							"name": "storage.type.annotation.lua"
-						}
-					},
-					"end": "(?=[\\n@#])"
-				},
-				{
-					"begin": "(?<=---\\s*)@protected",
-					"beginCaptures": {
-						"0": {
-							"name": "storage.type.annotation.lua"
-						}
-					},
-					"end": "(?=[\\n@#])"
-				},
-				{
-					"begin": "(?<=---\\s*)@package",
-					"beginCaptures": {
-						"0": {
-							"name": "storage.type.annotation.lua"
-						}
-					},
-					"end": "(?=[\\n@#])"
-				},
-				{
-					"begin": "(?<=---\\s*)@version",
-					"beginCaptures": {
-						"0": {
-							"name": "storage.type.annotation.lua"
-						}
-					},
-					"end": "(?=[\\n@#])",
-					"patterns": [
-						{
-							"match": "\\b(5\\.1|5\\.2|5\\.3|5\\.4|JIT)\\b",
-							"name": "support.class.lua"
-						},
-						{
-							"match": ",|\\>|\\<",
-							"name": "keyword.operator.lua"
-						}
-					]
-				},
-				{
-					"begin": "(?<=---\\s*)@see",
-					"beginCaptures": {
-						"0": {
-							"name": "storage.type.annotation.lua"
-						}
-					},
-					"end": "(?=[\\n@#])",
-					"patterns": [
-						{
-							"match": "\\b([a-zA-Z_\\*][a-zA-Z0-9_\\.\\*\\-]*)",
-							"name": "support.class.lua"
-						},
-						{
-							"match": "#",
-							"name": "keyword.operator.lua"
-						}
-					]
-				},
-				{
-					"begin": "(?<=---\\s*)@diagnostic",
-					"beginCaptures": {
-						"0": {
-							"name": "storage.type.annotation.lua"
-						}
-					},
-					"end": "(?=[\\n@#])",
-					"patterns": [
-						{
-							"begin": "([a-zA-Z_\\-0-9]+)[ \\t]*(:)?",
-							"beginCaptures": {
-								"1": {
-									"name": "keyword.other.unit"
-								},
-								"2": {
-									"name": "keyword.operator.unit"
-								}
-							},
-							"end": "(?=\\n)",
-							"patterns": [
-								{
-									"match": "\\b([a-zA-Z_\\*][a-zA-Z0-9_\\-]*)",
-									"name": "support.class.lua"
-								},
-								{
-									"match": ",",
-									"name": "keyword.operator.lua"
-								}
-							]
-						}
-					]
-				},
-				{
-					"begin": "(?<=---\\s*)@module",
-					"beginCaptures": {
-						"0": {
-							"name": "storage.type.annotation.lua"
-						}
-					},
-					"end": "(?=[\\n@#])",
-					"patterns": [
-						{
-							"include": "#string"
-						}
-					]
-				},
-				{
-					"match": "(?<=---\\s*)@(async|nodiscard)",
-					"name": "storage.type.annotation.lua"
-				},
-				{
-					"begin": "(?<=---)\\|\\s*[\\>\\+]?",
-					"beginCaptures": {
-						"0": {
-							"name": "storage.type.annotation.lua"
-						}
-					},
-					"end": "(?=[\\n@#])",
-					"patterns": [
-						{
-							"include": "#string"
-						}
-					]
-				}
-			]
-		},
-		"luadoc.type": {
-			"patterns": [
-				{
-					"begin": "\\bfun\\b",
-					"beginCaptures": {
-						"0": {
-							"name": "keyword.control.lua"
-						}
-					},
-					"end": "(?=[\\s#])",
-					"patterns": [
-						{
-							"match": "[\\(\\),:\\?][ \\t]*",
-							"name": "keyword.operator.lua"
-						},
-						{
-							"match": "([a-zA-Z_][a-zA-Z0-9_\\.\\*\\[\\]\\<\\>\\,\\-]*)(?<!,)[ \\t]*(?=\\??:)",
-							"name": "entity.name.variable.lua"
-						},
-						{
-							"include": "#luadoc.type"
-						},
-						{
-							"include": "#string"
-						}
-					]
-				},
-				{
-					"match": "\\<[a-zA-Z_\\*][a-zA-Z0-9_\\.\\*\\-]*\\>",
-					"name": "storage.type.generic.lua"
-				},
-				{
-					"match": "\\basync\\b",
-					"name": "entity.name.tag.lua"
-				},
-				{
-					"match": "[\\{\\}\\:\\,\\?\\|\\`][ \\t]*",
-					"name": "keyword.operator.lua"
-				},
-				{
-					"begin": "(?=[a-zA-Z_\\.\\*\"'\\[])",
-					"end": "(?=[\\s\\)\\,\\?\\:\\}\\|#])",
-					"patterns": [
-						{
-							"match": "([a-zA-Z0-9_\\.\\*\\[\\]\\<\\>\\,\\-]+)(?<!,)[ \\t]*",
-							"name": "support.type.lua"
-						},
-						{
-							"match": "(\\.\\.\\.)[ \\t]*",
-							"name": "constant.language.lua"
-						},
-						{
-							"include": "#string"
-						}
-					]
-				}
-			]
-		}
-	}
+  "name": "Lua",
+  "scopeName": "source.lua",
+  "patterns": [
+    {
+      "begin": "\\b(?:(local)\\s+)?(function)\\b(?![,:])",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.local.lua"
+        },
+        "2": {
+          "name": "keyword.control.lua"
+        }
+      },
+      "end": "(?<=[\\)\\-{}\\[\\]\"'])",
+      "name": "meta.function.lua",
+      "patterns": [
+        {
+          "include": "#comment"
+        },
+        {
+          "begin": "(\\()",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.definition.parameters.begin.lua"
+            }
+          },
+          "end": "(\\))|(?=[\\-\\.{}\\[\\]\"'])",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.definition.parameters.finish.lua"
+            }
+          },
+          "name": "meta.parameter.lua",
+          "patterns": [
+            {
+              "include": "#comment"
+            },
+            {
+              "match": "[a-zA-Z_][a-zA-Z0-9_]*",
+              "name": "variable.parameter.function.lua"
+            },
+            {
+              "match": ",",
+              "name": "punctuation.separator.arguments.lua"
+            },
+            {
+              "begin": ":",
+              "beginCaptures": {
+                "0": {
+                  "name": "punctuation.separator.arguments.lua"
+                }
+              },
+              "end": "(?=[\\),])",
+              "patterns": [
+                {
+                  "include": "#emmydoc.type"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "match": "\\b([a-zA-Z_][a-zA-Z0-9_]*)\\b\\s*(?=:)",
+          "name": "entity.name.class.lua"
+        },
+        {
+          "match": "\\b([a-zA-Z_][a-zA-Z0-9_]*)\\b",
+          "name": "entity.name.function.lua"
+        }
+      ]
+    },
+    {
+      "match": "(?<![\\w\\d.])0[xX][0-9A-Fa-f]+(\\.[0-9A-Fa-f]*)?([eE]-?\\d*)?([pP][-+]\\d+)?",
+      "name": "constant.numeric.float.hexadecimal.lua"
+    },
+    {
+      "match": "(?<![\\w\\d.])0[xX]\\.[0-9A-Fa-f]+([eE]-?\\d*)?([pP][-+]\\d+)?",
+      "name": "constant.numeric.float.hexadecimal.lua"
+    },
+    {
+      "match": "(?<![\\w\\d.])0[xX][0-9A-Fa-f]+(?![pPeE.0-9])",
+      "name": "constant.numeric.integer.hexadecimal.lua"
+    },
+    {
+      "match": "(?<![\\w\\d.])\\d+(\\.\\d*)?([eE]-?\\d*)?",
+      "name": "constant.numeric.float.lua"
+    },
+    {
+      "match": "(?<![\\w\\d.])\\.\\d+([eE]-?\\d*)?",
+      "name": "constant.numeric.float.lua"
+    },
+    {
+      "match": "(?<![\\w\\d.])\\d+(?![pPeE.0-9])",
+      "name": "constant.numeric.integer.lua"
+    },
+    {
+      "include": "#string"
+    },
+    {
+      "captures": {
+        "1": {
+          "name": "punctuation.definition.comment.lua"
+        }
+      },
+      "match": "\\A(#!).*$\\n?",
+      "name": "comment.line.shebang.lua"
+    },
+    {
+      "include": "#comment"
+    },
+    {
+      "captures": {
+        "1": {
+          "name": "keyword.control.goto.lua"
+        },
+        "2": {
+          "name": "string.tag.lua"
+        }
+      },
+      "match": "\\b(goto)\\s+([a-zA-Z_][a-zA-Z0-9_]*)"
+    },
+    {
+      "captures": {
+        "1": {
+          "name": "punctuation.section.embedded.begin.lua"
+        },
+        "2": {
+          "name": "punctuation.section.embedded.end.lua"
+        }
+      },
+      "match": "(::)\\s*[a-zA-Z_][a-zA-Z0-9_]*\\s*(::)",
+      "name": "string.tag.lua"
+    },
+    {
+      "match": "<\\s*(const|close)\\s*>",
+      "captures": {
+        "1": {
+          "name": "string.tag.lua"
+        }
+      }
+    },
+    {
+      "match": "\\<[a-zA-Z_\\*][a-zA-Z0-9_\\.\\*\\-]*\\>",
+      "name": "storage.type.generic.lua"
+    },
+    {
+      "match": "\\b(break|do|else|for|if|elseif|goto|return|then|repeat|while|until|end|in)\\b",
+      "name": "keyword.control.lua"
+    },
+    {
+      "match": "\\b(local|global)\\b",
+      "name": "keyword.local.lua"
+    },
+    {
+      "match": "\\b(function)\\b(?![,:])",
+      "name": "keyword.control.lua"
+    },
+    {
+      "match": "(?<![^.]\\.|:)\\b(false|nil(?!:)|true|_ENV|_G|_VERSION|math\\.(pi|huge|maxinteger|mininteger)|utf8\\.charpattern|io\\.(stdin|stdout|stderr)|package\\.(config|cpath|loaded|loaders|path|preload|searchers))\\b|(?<![.])\\.{3}(?!\\.)",
+      "name": "constant.language.lua"
+    },
+    {
+      "match": "(?<![^.]\\.|:)\\b(self)\\b",
+      "name": "variable.language.self.lua"
+    },
+    {
+      "match": "(?<![^.]\\.|:)\\b(assert|collectgarbage|dofile|error|getfenv|getmetatable|ipairs|load|loadfile|loadstring|module|next|pairs|pcall|print|rawequal|rawget|rawlen|rawset|require|select|setfenv|setmetatable|tonumber|tostring|type|unpack|xpcall)\\b(?!\\s*=(?!=))",
+      "name": "support.function.lua"
+    },
+    {
+      "match": "(?<![^.]\\.|:)\\b(async)\\b(?!\\s*=(?!=))",
+      "name": "entity.name.tag.lua"
+    },
+    {
+      "match": "(?<![^.]\\.|:)\\b(coroutine\\.(create|isyieldable|close|resume|running|status|wrap|yield)|string\\.(byte|char|dump|find|format|gmatch|gsub|len|lower|match|pack|packsize|rep|reverse|sub|unpack|upper)|table\\.(concat|insert|maxn|move|pack|remove|sort|unpack)|math\\.(abs|acos|asin|atan2?|ceil|cosh?|deg|exp|floor|fmod|frexp|ldexp|log|log10|max|min|modf|pow|rad|random|randomseed|sinh?|sqrt|tanh?|tointeger|type)|io\\.(close|flush|input|lines|open|output|popen|read|tmpfile|type|write)|os\\.(clock|date|difftime|execute|exit|getenv|remove|rename|setlocale|time|tmpname)|package\\.(loadlib|seeall|searchpath)|debug\\.(debug|[gs]etfenv|[gs]ethook|getinfo|[gs]etlocal|[gs]etmetatable|getregistry|[gs]etupvalue|[gs]etuservalue|set[Cc]stacklimit|traceback|upvalueid|upvaluejoin)|bit32\\.(arshift|band|bnot|bor|btest|bxor|extract|replace|lrotate|lshift|rrotate|rshift)|utf8\\.(char|codes|codepoint|len|offset))\\b(?!\\s*=(?!=))",
+      "name": "support.function.library.lua"
+    },
+    {
+      "match": "\\b(and|or|not|\\|\\||\\&\\&|\\!)\\b",
+      "name": "keyword.operator.lua"
+    },
+    {
+      "match": "\\b([a-zA-Z_][a-zA-Z0-9_]*)\\b(?=\\s*(?:[({\"']|\\[\\[))",
+      "name": "support.function.any-method.lua"
+    },
+    {
+      "match": "\\b([a-zA-Z_][a-zA-Z0-9_]*)\\b(?=\\s*\\??:)",
+      "name": "entity.name.class.lua"
+    },
+    {
+      "match": "(?<=[^.]\\.|:)\\b([a-zA-Z_][a-zA-Z0-9_]*)\\b(?!\\s*=\\s*\\b(function)\\b)",
+      "name": "entity.other.attribute.lua"
+    },
+    {
+      "match": "\\b([a-zA-Z_][a-zA-Z0-9_]*)\\b(?!\\s*=\\s*\\b(function)\\b)",
+      "name": "variable.other.lua"
+    },
+    {
+      "match": "\\b([a-zA-Z_][a-zA-Z0-9_]*)\\b(?=\\s*=\\s*\\b(function)\\b)",
+      "name": "entity.name.function.lua"
+    },
+    {
+      "match": "\\+|-|%|#|\\*|\\/|\\^|==?|~=|!=|<=?|>=?|(?<!\\.)\\.{2}(?!\\.)",
+      "name": "keyword.operator.lua"
+    }
+  ],
+  "repository": {
+    "escaped_char": {
+      "patterns": [
+        {
+          "match": "\\\\[abfnrtv\\\\\"'\\n]",
+          "name": "constant.character.escape.lua"
+        },
+        {
+          "match": "\\\\z[\\n\\t ]*",
+          "name": "constant.character.escape.lua"
+        },
+        {
+          "match": "\\\\\\d{1,3}",
+          "name": "constant.character.escape.byte.lua"
+        },
+        {
+          "match": "\\\\x[0-9A-Fa-f][0-9A-Fa-f]",
+          "name": "constant.character.escape.byte.lua"
+        },
+        {
+          "match": "\\\\u\\{[0-9A-Fa-f]+\\}",
+          "name": "constant.character.escape.unicode.lua"
+        },
+        {
+          "match": "\\\\.",
+          "name": "invalid.illegal.character.escape.lua"
+        }
+      ]
+    },
+    "string": {
+      "patterns": [
+        {
+          "begin": "'",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.begin.lua"
+            }
+          },
+          "end": "'[ \\t]*|(?=\\n)",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.end.lua"
+            }
+          },
+          "name": "string.quoted.single.lua",
+          "patterns": [
+            {
+              "include": "#escaped_char"
+            }
+          ]
+        },
+        {
+          "begin": "\"",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.begin.lua"
+            }
+          },
+          "end": "\"[ \\t]*|(?=\\n)",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.end.lua"
+            }
+          },
+          "name": "string.quoted.double.lua",
+          "patterns": [
+            {
+              "include": "#escaped_char"
+            }
+          ]
+        },
+        {
+          "begin": "`",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.begin.lua"
+            }
+          },
+          "end": "`[ \\t]*|(?=\\n)",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.end.lua"
+            }
+          },
+          "name": "string.quoted.double.lua"
+        },
+        {
+          "begin": "(?<=\\.cdef)\\s*(\\[(=*)\\[)",
+          "beginCaptures": {
+            "0": {
+              "name": "string.quoted.other.multiline.lua"
+            },
+            "1": {
+              "name": "punctuation.definition.string.begin.lua"
+            }
+          },
+          "contentName": "meta.embedded.lua",
+          "end": "(\\]\\2\\])[ \\t]*",
+          "endCaptures": {
+            "0": {
+              "name": "string.quoted.other.multiline.lua"
+            },
+            "1": {
+              "name": "punctuation.definition.string.end.lua"
+            }
+          },
+          "patterns": [
+            {
+              "include": "source.c"
+            }
+          ]
+        },
+        {
+          "begin": "(?<!--)\\[(=*)\\[",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.begin.lua"
+            }
+          },
+          "end": "\\]\\1\\][ \\t]*",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.end.lua"
+            }
+          },
+          "name": "string.quoted.other.multiline.lua"
+        }
+      ]
+    },
+    "comment": {
+      "patterns": [
+        {
+          "begin": "(^[ \\t]+)?(?=--)",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.whitespace.comment.leading.lua"
+            }
+          },
+          "end": "(?!\\G)((?!^)[ \\t]+\\n)?",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.whitespace.comment.trailing.lua"
+            }
+          },
+          "patterns": [
+            {
+              "begin": "--\\[(=*)\\[",
+              "beginCaptures": {
+                "0": {
+                  "name": "punctuation.definition.comment.begin.lua"
+                }
+              },
+              "end": "\\]\\1\\]",
+              "endCaptures": {
+                "0": {
+                  "name": "punctuation.definition.comment.end.lua"
+                }
+              },
+              "name": "comment.block.lua",
+              "patterns": [
+                {
+                  "include": "#comment_documentation_bracket"
+                }
+              ]
+            },
+            {
+              "begin": "----",
+              "beginCaptures": {
+                "0": {
+                  "name": "punctuation.definition.comment.lua"
+                }
+              },
+              "end": "\\n",
+              "name": "comment.line.double-dash.lua"
+            },
+            {
+              "begin": "---",
+              "beginCaptures": {
+                "0": {
+                  "name": "punctuation.definition.comment.lua"
+                }
+              },
+              "end": "\\n",
+              "name": "comment.line.double-dash.documentation.lua",
+              "patterns": [
+                {
+                  "include": "#emmydoc"
+                },
+                {
+                  "include": "#ldoc_summary"
+                },
+                {
+                  "include": "#ldoc_tag"
+                }
+              ]
+            },
+            {
+              "begin": "--",
+              "beginCaptures": {
+                "0": {
+                  "name": "punctuation.definition.comment.lua"
+                }
+              },
+              "end": "\\n",
+              "name": "comment.line.double-dash.lua",
+              "patterns": [
+                {
+                  "include": "#ldoc_tag"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "begin": "\\/\\*",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.definition.comment.begin.lua"
+            }
+          },
+          "end": "\\*\\/",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.definition.comment.end.lua"
+            }
+          },
+          "name": "comment.block.lua",
+          "patterns": [
+            {
+              "include": "#comment_documentation_asterisk"
+            }
+          ]
+        }
+      ]
+    },
+    "comment_documentation_asterisk": {
+      "begin": "(?<=/\\*\\*)([^*]|\\*(?!/))*$",
+      " ": "(^|\\G)[ \\t]*\\*(?!/)(?=([^*]|[*](?!/))*$)",
+      "patterns": [
+        {
+          "include": "#emmydoc"
+        },
+        {
+          "include": "#ldoc_tag"
+        }
+      ]
+    },
+    "comment_documentation_bracket": {
+      "begin": "(?<=--\\[\\[)([^-]|\\-(?!\\]\\]))*$",
+      "while": "(^|\\G)[ \\t]*-*(?!\\]\\])(?=([^-]|[-](?!\\]\\]))*$)",
+      "patterns": [
+        {
+          "include": "#emmydoc"
+        },
+        {
+          "include": "#ldoc_tag"
+        }
+      ]
+    },
+    "emmydoc": {
+      "patterns": [
+        {
+          "begin": "(?<=---[ \\t]*)@class",
+          "beginCaptures": {
+            "0": {
+              "name": "storage.type.annotation.lua"
+            }
+          },
+          "end": "(?=[\\n@#])",
+          "patterns": [
+            {
+              "match": "\\b([a-zA-Z_\\*][a-zA-Z0-9_\\.\\*\\-]*)",
+              "name": "support.class.lua"
+            },
+            {
+              "match": ":|,",
+              "name": "keyword.operator.lua"
+            }
+          ]
+        },
+        {
+          "begin": "(?<=---[ \\t]*)@enum",
+          "beginCaptures": {
+            "0": {
+              "name": "storage.type.annotation.lua"
+            }
+          },
+          "end": "(?=[\\n@#])",
+          "patterns": [
+            {
+              "begin": "\\b([a-zA-Z_\\*][a-zA-Z0-9_\\.\\*\\-]*)",
+              "beginCaptures": {
+                "0": {
+                  "name": "variable.lua"
+                }
+              },
+              "end": "(?=\\n)"
+            }
+          ]
+        },
+        {
+          "begin": "(?<=---[ \\t]*)@type",
+          "beginCaptures": {
+            "0": {
+              "name": "storage.type.annotation.lua"
+            }
+          },
+          "end": "(?=[\\n@#])",
+          "patterns": [
+            {
+              "include": "#emmydoc.type"
+            }
+          ]
+        },
+        {
+          "begin": "(?<=---[ \\t]*)@alias",
+          "beginCaptures": {
+            "0": {
+              "name": "storage.type.annotation.lua"
+            }
+          },
+          "end": "(?=[\\n@#])",
+          "patterns": [
+            {
+              "begin": "\\b([a-zA-Z_\\*][a-zA-Z0-9_\\.\\*\\-]*)",
+              "beginCaptures": {
+                "0": {
+                  "name": "variable.lua"
+                }
+              },
+              "end": "(?=[\\n#])",
+              "patterns": [
+                {
+                  "include": "#emmydoc.type"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "begin": "(?<=---[ \\t]*)(@operator)\\s*(\\b[a-z]+)?",
+          "beginCaptures": {
+            "1": {
+              "name": "storage.type.annotation.lua"
+            },
+            "2": {
+              "name": "support.function.library.lua"
+            }
+          },
+          "end": "(?=[\\n@#])",
+          "patterns": [
+            {
+              "include": "#emmydoc.type"
+            }
+          ]
+        },
+        {
+          "begin": "(?<=---[ \\t]*)@cast",
+          "beginCaptures": {
+            "0": {
+              "name": "storage.type.annotation.lua"
+            }
+          },
+          "end": "(?=[\\n@#])",
+          "patterns": [
+            {
+              "begin": "\\b([a-zA-Z_\\*][a-zA-Z0-9_\\.\\*\\-]*)",
+              "beginCaptures": {
+                "0": {
+                  "name": "variable.other.lua"
+                }
+              },
+              "end": "(?=\\n)",
+              "patterns": [
+                {
+                  "include": "#emmydoc.type"
+                },
+                {
+                  "match": "([+-|])",
+                  "name": "keyword.operator.lua"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "begin": "(?<=---[ \\t]*)@param",
+          "beginCaptures": {
+            "0": {
+              "name": "storage.type.annotation.lua"
+            }
+          },
+          "end": "(?=[\\n@#])",
+          "patterns": [
+            {
+              "begin": "\\b([a-zA-Z_][a-zA-Z0-9_]*)\\b(\\??)",
+              "beginCaptures": {
+                "1": {
+                  "name": "entity.name.variable.lua"
+                },
+                "2": {
+                  "name": "keyword.operator.lua"
+                }
+              },
+              "end": "(?=[\\n#])",
+              "patterns": [
+                {
+                  "include": "#emmydoc.type"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "begin": "(?<=---[ \\t]*)@return",
+          "beginCaptures": {
+            "0": {
+              "name": "storage.type.annotation.lua"
+            }
+          },
+          "end": "(?=[\\n@#])",
+          "patterns": [
+            {
+              "match": "\\?",
+              "name": "keyword.operator.lua"
+            },
+            {
+              "include": "#emmydoc.type"
+            }
+          ]
+        },
+        {
+          "begin": "(?<=---[ \\t]*)@field",
+          "beginCaptures": {
+            "0": {
+              "name": "storage.type.annotation.lua"
+            }
+          },
+          "end": "(?=[\\n@#])",
+          "patterns": [
+            {
+              "begin": "(\\b([a-zA-Z_][a-zA-Z0-9_]*)\\b|(\\[))(\\??)",
+              "beginCaptures": {
+                "2": {
+                  "name": "entity.name.variable.lua"
+                },
+                "3": {
+                  "name": "keyword.operator.lua"
+                }
+              },
+              "end": "(?=[\\n#])",
+              "patterns": [
+                {
+                  "include": "#string"
+                },
+                {
+                  "include": "#emmydoc.type"
+                },
+                {
+                  "match": "\\]",
+                  "name": "keyword.operator.lua"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "begin": "(?<=---[ \\t]*)@generic",
+          "beginCaptures": {
+            "0": {
+              "name": "storage.type.annotation.lua"
+            }
+          },
+          "end": "(?=[\\n@#])",
+          "patterns": [
+            {
+              "begin": "\\b([a-zA-Z_][a-zA-Z0-9_]*)\\b",
+              "beginCaptures": {
+                "0": {
+                  "name": "storage.type.generic.lua"
+                }
+              },
+              "end": "(?=\\n)|(,)",
+              "endCaptures": {
+                "0": {
+                  "name": "keyword.operator.lua"
+                }
+              },
+              "patterns": [
+                {
+                  "match": ":",
+                  "name": "keyword.operator.lua"
+                },
+                {
+                  "include": "#emmydoc.type"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "begin": "(?<=---[ \\t]*)@vararg",
+          "beginCaptures": {
+            "0": {
+              "name": "storage.type.annotation.lua"
+            }
+          },
+          "end": "(?=[\\n@#])",
+          "patterns": [
+            {
+              "include": "#emmydoc.type"
+            }
+          ]
+        },
+        {
+          "begin": "(?<=---[ \\t]*)@overload",
+          "beginCaptures": {
+            "0": {
+              "name": "storage.type.annotation.lua"
+            }
+          },
+          "end": "(?=[\\n@#])",
+          "patterns": [
+            {
+              "include": "#emmydoc.type"
+            }
+          ]
+        },
+        {
+          "begin": "(?<=---[ \\t]*)@deprecated",
+          "beginCaptures": {
+            "0": {
+              "name": "storage.type.annotation.lua"
+            }
+          },
+          "end": "(?=[\\n@#])"
+        },
+        {
+          "begin": "(?<=---[ \\t]*)@meta",
+          "beginCaptures": {
+            "0": {
+              "name": "storage.type.annotation.lua"
+            }
+          },
+          "end": "(?=[\\n@#])"
+        },
+        {
+          "begin": "(?<=---[ \\t]*)@private",
+          "beginCaptures": {
+            "0": {
+              "name": "storage.type.annotation.lua"
+            }
+          },
+          "end": "(?=[\\n@#])"
+        },
+        {
+          "begin": "(?<=---[ \\t]*)@protected",
+          "beginCaptures": {
+            "0": {
+              "name": "storage.type.annotation.lua"
+            }
+          },
+          "end": "(?=[\\n@#])"
+        },
+        {
+          "begin": "(?<=---[ \\t]*)@package",
+          "beginCaptures": {
+            "0": {
+              "name": "storage.type.annotation.lua"
+            }
+          },
+          "end": "(?=[\\n@#])"
+        },
+        {
+          "begin": "(?<=---[ \\t]*)@version",
+          "beginCaptures": {
+            "0": {
+              "name": "storage.type.annotation.lua"
+            }
+          },
+          "end": "(?=[\\n@#])",
+          "patterns": [
+            {
+              "match": "\\b(5\\.1|5\\.2|5\\.3|5\\.4|JIT)\\b",
+              "name": "support.class.lua"
+            },
+            {
+              "match": ",|\\>|\\<",
+              "name": "keyword.operator.lua"
+            }
+          ]
+        },
+        {
+          "begin": "(?<=---[ \\t]*)@see",
+          "beginCaptures": {
+            "0": {
+              "name": "storage.type.annotation.lua"
+            }
+          },
+          "end": "(?=[\\n@#])",
+          "patterns": [
+            {
+              "match": "\\b([a-zA-Z_\\*][a-zA-Z0-9_\\.\\*\\-]*)",
+              "name": "support.class.lua"
+            },
+            {
+              "match": "#",
+              "name": "keyword.operator.lua"
+            }
+          ]
+        },
+        {
+          "begin": "(?<=---[ \\t]*)@diagnostic",
+          "beginCaptures": {
+            "0": {
+              "name": "storage.type.annotation.lua"
+            }
+          },
+          "end": "(?=[\\n@#])",
+          "patterns": [
+            {
+              "begin": "([a-zA-Z_\\-0-9]+)[ \\t]*(:)?",
+              "beginCaptures": {
+                "1": {
+                  "name": "keyword.other.unit"
+                },
+                "2": {
+                  "name": "keyword.operator.unit"
+                }
+              },
+              "end": "(?=\\n)",
+              "patterns": [
+                {
+                  "match": "\\b([a-zA-Z_\\*][a-zA-Z0-9_\\-]*)",
+                  "name": "support.class.lua"
+                },
+                {
+                  "match": ",",
+                  "name": "keyword.operator.lua"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "begin": "(?<=---[ \\t]*)@module",
+          "beginCaptures": {
+            "0": {
+              "name": "storage.type.annotation.lua"
+            }
+          },
+          "end": "(?=[\\n@#])",
+          "patterns": [
+            {
+              "include": "#string"
+            }
+          ]
+        },
+        {
+          "match": "(?<=---[ \\t]*)@(async|nodiscard)",
+          "name": "storage.type.annotation.lua"
+        },
+        {
+          "begin": "(?<=---)\\|\\s*[\\>\\+]?",
+          "beginCaptures": {
+            "0": {
+              "name": "storage.type.annotation.lua"
+            }
+          },
+          "end": "(?=[\\n@#])",
+          "patterns": [
+            {
+              "include": "#string"
+            }
+          ]
+        }
+      ]
+    },
+    "emmydoc.type": {
+      "patterns": [
+        {
+          "begin": "\\bfun\\b",
+          "beginCaptures": {
+            "0": {
+              "name": "keyword.control.lua"
+            }
+          },
+          "end": "(?=[\\s#])",
+          "patterns": [
+            {
+              "match": "[\\(\\),:\\?][ \\t]*",
+              "name": "keyword.operator.lua"
+            },
+            {
+              "match": "([a-zA-Z_][a-zA-Z0-9_\\.\\*\\[\\]\\<\\>\\,\\-]*)(?<!,)[ \\t]*(?=\\??:)",
+              "name": "entity.name.variable.lua"
+            },
+            {
+              "include": "#emmydoc.type"
+            },
+            {
+              "include": "#string"
+            }
+          ]
+        },
+        {
+          "match": "\\<[a-zA-Z_\\*][a-zA-Z0-9_\\.\\*\\-]*\\>",
+          "name": "storage.type.generic.lua"
+        },
+        {
+          "match": "\\basync\\b",
+          "name": "entity.name.tag.lua"
+        },
+        {
+          "match": "[\\{\\}\\:\\,\\?\\|\\`][ \\t]*",
+          "name": "keyword.operator.lua"
+        },
+        {
+          "begin": "(?=[a-zA-Z_\\.\\*\"'\\[])",
+          "end": "(?=[\\s\\)\\,\\?\\:\\}\\|#])",
+          "patterns": [
+            {
+              "match": "([a-zA-Z0-9_\\.\\*\\[\\]\\<\\>\\,\\-]+)(?<!,)[ \\t]*",
+              "name": "support.type.lua"
+            },
+            {
+              "match": "(\\.\\.\\.)[ \\t]*",
+              "name": "constant.language.lua"
+            },
+            {
+              "include": "#string"
+            }
+          ]
+        }
+      ]
+    },
+    "ldoc_tag": {
+      "match": "\\G[ \\t]*(@)(alias|annotation|author|charset|class|classmod|comment|constructor|copyright|description|example|export|factory|field|file|fixme|function|include|lfunction|license|local|module|name|param|pragma|private|raise|release|return|script|section|see|set|static|submodule|summary|tfield|thread|tparam|treturn|todo|topic|type|usage|warning|within)\\b",
+      "end": "(?!@)\\b",
+      "captures": {
+        "1": {
+          "name": "punctuation.definition.block.tag.ldoc"
+        },
+        "2": {
+          "name": "storage.type.class.ldoc"
+        }
+      }
+    },
+    "ldoc_summary": {
+      "begin": "\\G ?(?!@\\w+| )",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.comment.lua"
+        }
+      },
+      "end": "$",
+      "name": "entity.name.section.ldoc"
+    }
+  }
 }

--- a/lua.tmLanguage.json
+++ b/lua.tmLanguage.json
@@ -1,967 +1,967 @@
 {
-  "name": "Lua",
-  "scopeName": "source.lua",
-  "patterns": [
-    {
-      "begin": "\\b(?:(local)\\s+)?(function)\\b(?![,:])",
-      "beginCaptures": {
-        "1": {
-          "name": "keyword.local.lua"
-        },
-        "2": {
-          "name": "keyword.control.lua"
-        }
-      },
-      "end": "(?<=[\\)\\-{}\\[\\]\"'])",
-      "name": "meta.function.lua",
-      "patterns": [
-        {
-          "include": "#comment"
-        },
-        {
-          "begin": "(\\()",
-          "beginCaptures": {
-            "1": {
-              "name": "punctuation.definition.parameters.begin.lua"
-            }
-          },
-          "end": "(\\))|(?=[\\-\\.{}\\[\\]\"'])",
-          "endCaptures": {
-            "1": {
-              "name": "punctuation.definition.parameters.finish.lua"
-            }
-          },
-          "name": "meta.parameter.lua",
-          "patterns": [
-            {
-              "include": "#comment"
-            },
-            {
-              "match": "[a-zA-Z_][a-zA-Z0-9_]*",
-              "name": "variable.parameter.function.lua"
-            },
-            {
-              "match": ",",
-              "name": "punctuation.separator.arguments.lua"
-            },
-            {
-              "begin": ":",
-              "beginCaptures": {
-                "0": {
-                  "name": "punctuation.separator.arguments.lua"
-                }
-              },
-              "end": "(?=[\\),])",
-              "patterns": [
-                {
-                  "include": "#emmydoc.type"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "match": "\\b([a-zA-Z_][a-zA-Z0-9_]*)\\b\\s*(?=:)",
-          "name": "entity.name.class.lua"
-        },
-        {
-          "match": "\\b([a-zA-Z_][a-zA-Z0-9_]*)\\b",
-          "name": "entity.name.function.lua"
-        }
-      ]
-    },
-    {
-      "match": "(?<![\\w\\d.])0[xX][0-9A-Fa-f]+(\\.[0-9A-Fa-f]*)?([eE]-?\\d*)?([pP][-+]\\d+)?",
-      "name": "constant.numeric.float.hexadecimal.lua"
-    },
-    {
-      "match": "(?<![\\w\\d.])0[xX]\\.[0-9A-Fa-f]+([eE]-?\\d*)?([pP][-+]\\d+)?",
-      "name": "constant.numeric.float.hexadecimal.lua"
-    },
-    {
-      "match": "(?<![\\w\\d.])0[xX][0-9A-Fa-f]+(?![pPeE.0-9])",
-      "name": "constant.numeric.integer.hexadecimal.lua"
-    },
-    {
-      "match": "(?<![\\w\\d.])\\d+(\\.\\d*)?([eE]-?\\d*)?",
-      "name": "constant.numeric.float.lua"
-    },
-    {
-      "match": "(?<![\\w\\d.])\\.\\d+([eE]-?\\d*)?",
-      "name": "constant.numeric.float.lua"
-    },
-    {
-      "match": "(?<![\\w\\d.])\\d+(?![pPeE.0-9])",
-      "name": "constant.numeric.integer.lua"
-    },
-    {
-      "include": "#string"
-    },
-    {
-      "captures": {
-        "1": {
-          "name": "punctuation.definition.comment.lua"
-        }
-      },
-      "match": "\\A(#!).*$\\n?",
-      "name": "comment.line.shebang.lua"
-    },
-    {
-      "include": "#comment"
-    },
-    {
-      "captures": {
-        "1": {
-          "name": "keyword.control.goto.lua"
-        },
-        "2": {
-          "name": "string.tag.lua"
-        }
-      },
-      "match": "\\b(goto)\\s+([a-zA-Z_][a-zA-Z0-9_]*)"
-    },
-    {
-      "captures": {
-        "1": {
-          "name": "punctuation.section.embedded.begin.lua"
-        },
-        "2": {
-          "name": "punctuation.section.embedded.end.lua"
-        }
-      },
-      "match": "(::)\\s*[a-zA-Z_][a-zA-Z0-9_]*\\s*(::)",
-      "name": "string.tag.lua"
-    },
-    {
-      "match": "<\\s*(const|close)\\s*>",
-      "captures": {
-        "1": {
-          "name": "string.tag.lua"
-        }
-      }
-    },
-    {
-      "match": "\\<[a-zA-Z_\\*][a-zA-Z0-9_\\.\\*\\-]*\\>",
-      "name": "storage.type.generic.lua"
-    },
-    {
-      "match": "\\b(break|do|else|for|if|elseif|goto|return|then|repeat|while|until|end|in)\\b",
-      "name": "keyword.control.lua"
-    },
-    {
-      "match": "\\b(local|global)\\b",
-      "name": "keyword.local.lua"
-    },
-    {
-      "match": "\\b(function)\\b(?![,:])",
-      "name": "keyword.control.lua"
-    },
-    {
-      "match": "(?<![^.]\\.|:)\\b(false|nil(?!:)|true|_ENV|_G|_VERSION|math\\.(pi|huge|maxinteger|mininteger)|utf8\\.charpattern|io\\.(stdin|stdout|stderr)|package\\.(config|cpath|loaded|loaders|path|preload|searchers))\\b|(?<![.])\\.{3}(?!\\.)",
-      "name": "constant.language.lua"
-    },
-    {
-      "match": "(?<![^.]\\.|:)\\b(self)\\b",
-      "name": "variable.language.self.lua"
-    },
-    {
-      "match": "(?<![^.]\\.|:)\\b(assert|collectgarbage|dofile|error|getfenv|getmetatable|ipairs|load|loadfile|loadstring|module|next|pairs|pcall|print|rawequal|rawget|rawlen|rawset|require|select|setfenv|setmetatable|tonumber|tostring|type|unpack|xpcall)\\b(?!\\s*=(?!=))",
-      "name": "support.function.lua"
-    },
-    {
-      "match": "(?<![^.]\\.|:)\\b(async)\\b(?!\\s*=(?!=))",
-      "name": "entity.name.tag.lua"
-    },
-    {
-      "match": "(?<![^.]\\.|:)\\b(coroutine\\.(create|isyieldable|close|resume|running|status|wrap|yield)|string\\.(byte|char|dump|find|format|gmatch|gsub|len|lower|match|pack|packsize|rep|reverse|sub|unpack|upper)|table\\.(concat|insert|maxn|move|pack|remove|sort|unpack)|math\\.(abs|acos|asin|atan2?|ceil|cosh?|deg|exp|floor|fmod|frexp|ldexp|log|log10|max|min|modf|pow|rad|random|randomseed|sinh?|sqrt|tanh?|tointeger|type)|io\\.(close|flush|input|lines|open|output|popen|read|tmpfile|type|write)|os\\.(clock|date|difftime|execute|exit|getenv|remove|rename|setlocale|time|tmpname)|package\\.(loadlib|seeall|searchpath)|debug\\.(debug|[gs]etfenv|[gs]ethook|getinfo|[gs]etlocal|[gs]etmetatable|getregistry|[gs]etupvalue|[gs]etuservalue|set[Cc]stacklimit|traceback|upvalueid|upvaluejoin)|bit32\\.(arshift|band|bnot|bor|btest|bxor|extract|replace|lrotate|lshift|rrotate|rshift)|utf8\\.(char|codes|codepoint|len|offset))\\b(?!\\s*=(?!=))",
-      "name": "support.function.library.lua"
-    },
-    {
-      "match": "\\b(and|or|not|\\|\\||\\&\\&|\\!)\\b",
-      "name": "keyword.operator.lua"
-    },
-    {
-      "match": "\\b([a-zA-Z_][a-zA-Z0-9_]*)\\b(?=\\s*(?:[({\"']|\\[\\[))",
-      "name": "support.function.any-method.lua"
-    },
-    {
-      "match": "\\b([a-zA-Z_][a-zA-Z0-9_]*)\\b(?=\\s*\\??:)",
-      "name": "entity.name.class.lua"
-    },
-    {
-      "match": "(?<=[^.]\\.|:)\\b([a-zA-Z_][a-zA-Z0-9_]*)\\b(?!\\s*=\\s*\\b(function)\\b)",
-      "name": "entity.other.attribute.lua"
-    },
-    {
-      "match": "\\b([a-zA-Z_][a-zA-Z0-9_]*)\\b(?!\\s*=\\s*\\b(function)\\b)",
-      "name": "variable.other.lua"
-    },
-    {
-      "match": "\\b([a-zA-Z_][a-zA-Z0-9_]*)\\b(?=\\s*=\\s*\\b(function)\\b)",
-      "name": "entity.name.function.lua"
-    },
-    {
-      "match": "\\+|-|%|#|\\*|\\/|\\^|==?|~=|!=|<=?|>=?|(?<!\\.)\\.{2}(?!\\.)",
-      "name": "keyword.operator.lua"
-    }
-  ],
-  "repository": {
-    "escaped_char": {
-      "patterns": [
-        {
-          "match": "\\\\[abfnrtv\\\\\"'\\n]",
-          "name": "constant.character.escape.lua"
-        },
-        {
-          "match": "\\\\z[\\n\\t ]*",
-          "name": "constant.character.escape.lua"
-        },
-        {
-          "match": "\\\\\\d{1,3}",
-          "name": "constant.character.escape.byte.lua"
-        },
-        {
-          "match": "\\\\x[0-9A-Fa-f][0-9A-Fa-f]",
-          "name": "constant.character.escape.byte.lua"
-        },
-        {
-          "match": "\\\\u\\{[0-9A-Fa-f]+\\}",
-          "name": "constant.character.escape.unicode.lua"
-        },
-        {
-          "match": "\\\\.",
-          "name": "invalid.illegal.character.escape.lua"
-        }
-      ]
-    },
-    "string": {
-      "patterns": [
-        {
-          "begin": "'",
-          "beginCaptures": {
-            "0": {
-              "name": "punctuation.definition.string.begin.lua"
-            }
-          },
-          "end": "'[ \\t]*|(?=\\n)",
-          "endCaptures": {
-            "0": {
-              "name": "punctuation.definition.string.end.lua"
-            }
-          },
-          "name": "string.quoted.single.lua",
-          "patterns": [
-            {
-              "include": "#escaped_char"
-            }
-          ]
-        },
-        {
-          "begin": "\"",
-          "beginCaptures": {
-            "0": {
-              "name": "punctuation.definition.string.begin.lua"
-            }
-          },
-          "end": "\"[ \\t]*|(?=\\n)",
-          "endCaptures": {
-            "0": {
-              "name": "punctuation.definition.string.end.lua"
-            }
-          },
-          "name": "string.quoted.double.lua",
-          "patterns": [
-            {
-              "include": "#escaped_char"
-            }
-          ]
-        },
-        {
-          "begin": "`",
-          "beginCaptures": {
-            "0": {
-              "name": "punctuation.definition.string.begin.lua"
-            }
-          },
-          "end": "`[ \\t]*|(?=\\n)",
-          "endCaptures": {
-            "0": {
-              "name": "punctuation.definition.string.end.lua"
-            }
-          },
-          "name": "string.quoted.double.lua"
-        },
-        {
-          "begin": "(?<=\\.cdef)\\s*(\\[(=*)\\[)",
-          "beginCaptures": {
-            "0": {
-              "name": "string.quoted.other.multiline.lua"
-            },
-            "1": {
-              "name": "punctuation.definition.string.begin.lua"
-            }
-          },
-          "contentName": "meta.embedded.lua",
-          "end": "(\\]\\2\\])[ \\t]*",
-          "endCaptures": {
-            "0": {
-              "name": "string.quoted.other.multiline.lua"
-            },
-            "1": {
-              "name": "punctuation.definition.string.end.lua"
-            }
-          },
-          "patterns": [
-            {
-              "include": "source.c"
-            }
-          ]
-        },
-        {
-          "begin": "(?<!--)\\[(=*)\\[",
-          "beginCaptures": {
-            "0": {
-              "name": "punctuation.definition.string.begin.lua"
-            }
-          },
-          "end": "\\]\\1\\][ \\t]*",
-          "endCaptures": {
-            "0": {
-              "name": "punctuation.definition.string.end.lua"
-            }
-          },
-          "name": "string.quoted.other.multiline.lua"
-        }
-      ]
-    },
-    "comment": {
-      "patterns": [
-        {
-          "begin": "(^[ \\t]+)?(?=--)",
-          "beginCaptures": {
-            "1": {
-              "name": "punctuation.whitespace.comment.leading.lua"
-            }
-          },
-          "end": "(?!\\G)((?!^)[ \\t]+\\n)?",
-          "endCaptures": {
-            "1": {
-              "name": "punctuation.whitespace.comment.trailing.lua"
-            }
-          },
-          "patterns": [
-            {
-              "begin": "--\\[(=*)\\[",
-              "beginCaptures": {
-                "0": {
-                  "name": "punctuation.definition.comment.begin.lua"
-                }
-              },
-              "end": "\\]\\1\\]",
-              "endCaptures": {
-                "0": {
-                  "name": "punctuation.definition.comment.end.lua"
-                }
-              },
-              "name": "comment.block.lua",
-              "patterns": [
-                {
-                  "include": "#comment_documentation_bracket"
-                }
-              ]
-            },
-            {
-              "begin": "----",
-              "beginCaptures": {
-                "0": {
-                  "name": "punctuation.definition.comment.lua"
-                }
-              },
-              "end": "\\n",
-              "name": "comment.line.double-dash.lua"
-            },
-            {
-              "begin": "---",
-              "beginCaptures": {
-                "0": {
-                  "name": "punctuation.definition.comment.lua"
-                }
-              },
-              "end": "\\n",
-              "name": "comment.line.double-dash.documentation.lua",
-              "patterns": [
-                {
-                  "include": "#emmydoc"
-                },
-                {
-                  "include": "#ldoc_summary"
-                },
-                {
-                  "include": "#ldoc_tag"
-                }
-              ]
-            },
-            {
-              "begin": "--",
-              "beginCaptures": {
-                "0": {
-                  "name": "punctuation.definition.comment.lua"
-                }
-              },
-              "end": "\\n",
-              "name": "comment.line.double-dash.lua",
-              "patterns": [
-                {
-                  "include": "#ldoc_tag"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "begin": "\\/\\*",
-          "beginCaptures": {
-            "0": {
-              "name": "punctuation.definition.comment.begin.lua"
-            }
-          },
-          "end": "\\*\\/",
-          "endCaptures": {
-            "0": {
-              "name": "punctuation.definition.comment.end.lua"
-            }
-          },
-          "name": "comment.block.lua",
-          "patterns": [
-            {
-              "include": "#comment_documentation_asterisk"
-            }
-          ]
-        }
-      ]
-    },
-    "comment_documentation_asterisk": {
-      "begin": "(?<=/\\*\\*)([^*]|\\*(?!/))*$",
-      " ": "(^|\\G)[ \\t]*\\*(?!/)(?=([^*]|[*](?!/))*$)",
-      "patterns": [
-        {
-          "include": "#emmydoc"
-        },
-        {
-          "include": "#ldoc_tag"
-        }
-      ]
-    },
-    "comment_documentation_bracket": {
-      "begin": "(?<=--\\[\\[)([^-]|\\-(?!\\]\\]))*$",
-      "while": "(^|\\G)[ \\t]*-*(?!\\]\\])(?=([^-]|[-](?!\\]\\]))*$)",
-      "patterns": [
-        {
-          "include": "#emmydoc"
-        },
-        {
-          "include": "#ldoc_tag"
-        }
-      ]
-    },
-    "emmydoc": {
-      "patterns": [
-        {
-          "begin": "(?<=---[ \\t]*)@class",
-          "beginCaptures": {
-            "0": {
-              "name": "storage.type.annotation.lua"
-            }
-          },
-          "end": "(?=[\\n@#])",
-          "patterns": [
-            {
-              "match": "\\b([a-zA-Z_\\*][a-zA-Z0-9_\\.\\*\\-]*)",
-              "name": "support.class.lua"
-            },
-            {
-              "match": ":|,",
-              "name": "keyword.operator.lua"
-            }
-          ]
-        },
-        {
-          "begin": "(?<=---[ \\t]*)@enum",
-          "beginCaptures": {
-            "0": {
-              "name": "storage.type.annotation.lua"
-            }
-          },
-          "end": "(?=[\\n@#])",
-          "patterns": [
-            {
-              "begin": "\\b([a-zA-Z_\\*][a-zA-Z0-9_\\.\\*\\-]*)",
-              "beginCaptures": {
-                "0": {
-                  "name": "variable.lua"
-                }
-              },
-              "end": "(?=\\n)"
-            }
-          ]
-        },
-        {
-          "begin": "(?<=---[ \\t]*)@type",
-          "beginCaptures": {
-            "0": {
-              "name": "storage.type.annotation.lua"
-            }
-          },
-          "end": "(?=[\\n@#])",
-          "patterns": [
-            {
-              "include": "#emmydoc.type"
-            }
-          ]
-        },
-        {
-          "begin": "(?<=---[ \\t]*)@alias",
-          "beginCaptures": {
-            "0": {
-              "name": "storage.type.annotation.lua"
-            }
-          },
-          "end": "(?=[\\n@#])",
-          "patterns": [
-            {
-              "begin": "\\b([a-zA-Z_\\*][a-zA-Z0-9_\\.\\*\\-]*)",
-              "beginCaptures": {
-                "0": {
-                  "name": "variable.lua"
-                }
-              },
-              "end": "(?=[\\n#])",
-              "patterns": [
-                {
-                  "include": "#emmydoc.type"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "begin": "(?<=---[ \\t]*)(@operator)\\s*(\\b[a-z]+)?",
-          "beginCaptures": {
-            "1": {
-              "name": "storage.type.annotation.lua"
-            },
-            "2": {
-              "name": "support.function.library.lua"
-            }
-          },
-          "end": "(?=[\\n@#])",
-          "patterns": [
-            {
-              "include": "#emmydoc.type"
-            }
-          ]
-        },
-        {
-          "begin": "(?<=---[ \\t]*)@cast",
-          "beginCaptures": {
-            "0": {
-              "name": "storage.type.annotation.lua"
-            }
-          },
-          "end": "(?=[\\n@#])",
-          "patterns": [
-            {
-              "begin": "\\b([a-zA-Z_\\*][a-zA-Z0-9_\\.\\*\\-]*)",
-              "beginCaptures": {
-                "0": {
-                  "name": "variable.other.lua"
-                }
-              },
-              "end": "(?=\\n)",
-              "patterns": [
-                {
-                  "include": "#emmydoc.type"
-                },
-                {
-                  "match": "([+-|])",
-                  "name": "keyword.operator.lua"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "begin": "(?<=---[ \\t]*)@param",
-          "beginCaptures": {
-            "0": {
-              "name": "storage.type.annotation.lua"
-            }
-          },
-          "end": "(?=[\\n@#])",
-          "patterns": [
-            {
-              "begin": "\\b([a-zA-Z_][a-zA-Z0-9_]*)\\b(\\??)",
-              "beginCaptures": {
-                "1": {
-                  "name": "entity.name.variable.lua"
-                },
-                "2": {
-                  "name": "keyword.operator.lua"
-                }
-              },
-              "end": "(?=[\\n#])",
-              "patterns": [
-                {
-                  "include": "#emmydoc.type"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "begin": "(?<=---[ \\t]*)@return",
-          "beginCaptures": {
-            "0": {
-              "name": "storage.type.annotation.lua"
-            }
-          },
-          "end": "(?=[\\n@#])",
-          "patterns": [
-            {
-              "match": "\\?",
-              "name": "keyword.operator.lua"
-            },
-            {
-              "include": "#emmydoc.type"
-            }
-          ]
-        },
-        {
-          "begin": "(?<=---[ \\t]*)@field",
-          "beginCaptures": {
-            "0": {
-              "name": "storage.type.annotation.lua"
-            }
-          },
-          "end": "(?=[\\n@#])",
-          "patterns": [
-            {
-              "begin": "(\\b([a-zA-Z_][a-zA-Z0-9_]*)\\b|(\\[))(\\??)",
-              "beginCaptures": {
-                "2": {
-                  "name": "entity.name.variable.lua"
-                },
-                "3": {
-                  "name": "keyword.operator.lua"
-                }
-              },
-              "end": "(?=[\\n#])",
-              "patterns": [
-                {
-                  "include": "#string"
-                },
-                {
-                  "include": "#emmydoc.type"
-                },
-                {
-                  "match": "\\]",
-                  "name": "keyword.operator.lua"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "begin": "(?<=---[ \\t]*)@generic",
-          "beginCaptures": {
-            "0": {
-              "name": "storage.type.annotation.lua"
-            }
-          },
-          "end": "(?=[\\n@#])",
-          "patterns": [
-            {
-              "begin": "\\b([a-zA-Z_][a-zA-Z0-9_]*)\\b",
-              "beginCaptures": {
-                "0": {
-                  "name": "storage.type.generic.lua"
-                }
-              },
-              "end": "(?=\\n)|(,)",
-              "endCaptures": {
-                "0": {
-                  "name": "keyword.operator.lua"
-                }
-              },
-              "patterns": [
-                {
-                  "match": ":",
-                  "name": "keyword.operator.lua"
-                },
-                {
-                  "include": "#emmydoc.type"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "begin": "(?<=---[ \\t]*)@vararg",
-          "beginCaptures": {
-            "0": {
-              "name": "storage.type.annotation.lua"
-            }
-          },
-          "end": "(?=[\\n@#])",
-          "patterns": [
-            {
-              "include": "#emmydoc.type"
-            }
-          ]
-        },
-        {
-          "begin": "(?<=---[ \\t]*)@overload",
-          "beginCaptures": {
-            "0": {
-              "name": "storage.type.annotation.lua"
-            }
-          },
-          "end": "(?=[\\n@#])",
-          "patterns": [
-            {
-              "include": "#emmydoc.type"
-            }
-          ]
-        },
-        {
-          "begin": "(?<=---[ \\t]*)@deprecated",
-          "beginCaptures": {
-            "0": {
-              "name": "storage.type.annotation.lua"
-            }
-          },
-          "end": "(?=[\\n@#])"
-        },
-        {
-          "begin": "(?<=---[ \\t]*)@meta",
-          "beginCaptures": {
-            "0": {
-              "name": "storage.type.annotation.lua"
-            }
-          },
-          "end": "(?=[\\n@#])"
-        },
-        {
-          "begin": "(?<=---[ \\t]*)@private",
-          "beginCaptures": {
-            "0": {
-              "name": "storage.type.annotation.lua"
-            }
-          },
-          "end": "(?=[\\n@#])"
-        },
-        {
-          "begin": "(?<=---[ \\t]*)@protected",
-          "beginCaptures": {
-            "0": {
-              "name": "storage.type.annotation.lua"
-            }
-          },
-          "end": "(?=[\\n@#])"
-        },
-        {
-          "begin": "(?<=---[ \\t]*)@package",
-          "beginCaptures": {
-            "0": {
-              "name": "storage.type.annotation.lua"
-            }
-          },
-          "end": "(?=[\\n@#])"
-        },
-        {
-          "begin": "(?<=---[ \\t]*)@version",
-          "beginCaptures": {
-            "0": {
-              "name": "storage.type.annotation.lua"
-            }
-          },
-          "end": "(?=[\\n@#])",
-          "patterns": [
-            {
-              "match": "\\b(5\\.1|5\\.2|5\\.3|5\\.4|JIT)\\b",
-              "name": "support.class.lua"
-            },
-            {
-              "match": ",|\\>|\\<",
-              "name": "keyword.operator.lua"
-            }
-          ]
-        },
-        {
-          "begin": "(?<=---[ \\t]*)@see",
-          "beginCaptures": {
-            "0": {
-              "name": "storage.type.annotation.lua"
-            }
-          },
-          "end": "(?=[\\n@#])",
-          "patterns": [
-            {
-              "match": "\\b([a-zA-Z_\\*][a-zA-Z0-9_\\.\\*\\-]*)",
-              "name": "support.class.lua"
-            },
-            {
-              "match": "#",
-              "name": "keyword.operator.lua"
-            }
-          ]
-        },
-        {
-          "begin": "(?<=---[ \\t]*)@diagnostic",
-          "beginCaptures": {
-            "0": {
-              "name": "storage.type.annotation.lua"
-            }
-          },
-          "end": "(?=[\\n@#])",
-          "patterns": [
-            {
-              "begin": "([a-zA-Z_\\-0-9]+)[ \\t]*(:)?",
-              "beginCaptures": {
-                "1": {
-                  "name": "keyword.other.unit"
-                },
-                "2": {
-                  "name": "keyword.operator.unit"
-                }
-              },
-              "end": "(?=\\n)",
-              "patterns": [
-                {
-                  "match": "\\b([a-zA-Z_\\*][a-zA-Z0-9_\\-]*)",
-                  "name": "support.class.lua"
-                },
-                {
-                  "match": ",",
-                  "name": "keyword.operator.lua"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "begin": "(?<=---[ \\t]*)@module",
-          "beginCaptures": {
-            "0": {
-              "name": "storage.type.annotation.lua"
-            }
-          },
-          "end": "(?=[\\n@#])",
-          "patterns": [
-            {
-              "include": "#string"
-            }
-          ]
-        },
-        {
-          "match": "(?<=---[ \\t]*)@(async|nodiscard)",
-          "name": "storage.type.annotation.lua"
-        },
-        {
-          "begin": "(?<=---)\\|\\s*[\\>\\+]?",
-          "beginCaptures": {
-            "0": {
-              "name": "storage.type.annotation.lua"
-            }
-          },
-          "end": "(?=[\\n@#])",
-          "patterns": [
-            {
-              "include": "#string"
-            }
-          ]
-        }
-      ]
-    },
-    "emmydoc.type": {
-      "patterns": [
-        {
-          "begin": "\\bfun\\b",
-          "beginCaptures": {
-            "0": {
-              "name": "keyword.control.lua"
-            }
-          },
-          "end": "(?=[\\s#])",
-          "patterns": [
-            {
-              "match": "[\\(\\),:\\?][ \\t]*",
-              "name": "keyword.operator.lua"
-            },
-            {
-              "match": "([a-zA-Z_][a-zA-Z0-9_\\.\\*\\[\\]\\<\\>\\,\\-]*)(?<!,)[ \\t]*(?=\\??:)",
-              "name": "entity.name.variable.lua"
-            },
-            {
-              "include": "#emmydoc.type"
-            },
-            {
-              "include": "#string"
-            }
-          ]
-        },
-        {
-          "match": "\\<[a-zA-Z_\\*][a-zA-Z0-9_\\.\\*\\-]*\\>",
-          "name": "storage.type.generic.lua"
-        },
-        {
-          "match": "\\basync\\b",
-          "name": "entity.name.tag.lua"
-        },
-        {
-          "match": "[\\{\\}\\:\\,\\?\\|\\`][ \\t]*",
-          "name": "keyword.operator.lua"
-        },
-        {
-          "begin": "(?=[a-zA-Z_\\.\\*\"'\\[])",
-          "end": "(?=[\\s\\)\\,\\?\\:\\}\\|#])",
-          "patterns": [
-            {
-              "match": "([a-zA-Z0-9_\\.\\*\\[\\]\\<\\>\\,\\-]+)(?<!,)[ \\t]*",
-              "name": "support.type.lua"
-            },
-            {
-              "match": "(\\.\\.\\.)[ \\t]*",
-              "name": "constant.language.lua"
-            },
-            {
-              "include": "#string"
-            }
-          ]
-        }
-      ]
-    },
-    "ldoc_tag": {
-      "match": "\\G[ \\t]*(@)(alias|annotation|author|charset|class|classmod|comment|constructor|copyright|description|example|export|factory|field|file|fixme|function|include|lfunction|license|local|module|name|param|pragma|private|raise|release|return|script|section|see|set|static|submodule|summary|tfield|thread|tparam|treturn|todo|topic|type|usage|warning|within)\\b",
-      "end": "(?!@)\\b",
-      "captures": {
-        "1": {
-          "name": "punctuation.definition.block.tag.ldoc"
-        },
-        "2": {
-          "name": "storage.type.class.ldoc"
-        }
-      }
-    },
-    "ldoc_summary": {
-      "begin": "\\G ?(?!@\\w+| )",
-      "beginCaptures": {
-        "0": {
-          "name": "punctuation.definition.comment.lua"
-        }
-      },
-      "end": "$",
-      "name": "entity.name.section.ldoc"
-    }
-  }
+	"name": "Lua",
+	"scopeName": "source.lua",
+	"patterns": [
+		{
+			"begin": "\\b(?:(local)\\s+)?(function)\\b(?![,:])",
+			"beginCaptures": {
+				"1": {
+					"name": "keyword.local.lua"
+				},
+				"2": {
+					"name": "keyword.control.lua"
+				}
+			},
+			"end": "(?<=[\\)\\-{}\\[\\]\"'])",
+			"name": "meta.function.lua",
+			"patterns": [
+				{
+					"include": "#comment"
+				},
+				{
+					"begin": "(\\()",
+					"beginCaptures": {
+						"1": {
+							"name": "punctuation.definition.parameters.begin.lua"
+						}
+					},
+					"end": "(\\))|(?=[\\-\\.{}\\[\\]\"'])",
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.definition.parameters.finish.lua"
+						}
+					},
+					"name": "meta.parameter.lua",
+					"patterns": [
+						{
+							"include": "#comment"
+						},
+						{
+							"match": "[a-zA-Z_][a-zA-Z0-9_]*",
+							"name": "variable.parameter.function.lua"
+						},
+						{
+							"match": ",",
+							"name": "punctuation.separator.arguments.lua"
+						},
+						{
+							"begin": ":",
+							"beginCaptures": {
+								"0": {
+									"name": "punctuation.separator.arguments.lua"
+								}
+							},
+							"end": "(?=[\\),])",
+							"patterns": [
+								{
+									"include": "#emmydoc.type"
+								}
+							]
+						}
+					]
+				},
+				{
+					"match": "\\b([a-zA-Z_][a-zA-Z0-9_]*)\\b\\s*(?=:)",
+					"name": "entity.name.class.lua"
+				},
+				{
+					"match": "\\b([a-zA-Z_][a-zA-Z0-9_]*)\\b",
+					"name": "entity.name.function.lua"
+				}
+			]
+		},
+		{
+			"match": "(?<![\\w\\d.])0[xX][0-9A-Fa-f]+(\\.[0-9A-Fa-f]*)?([eE]-?\\d*)?([pP][-+]\\d+)?",
+			"name": "constant.numeric.float.hexadecimal.lua"
+		},
+		{
+			"match": "(?<![\\w\\d.])0[xX]\\.[0-9A-Fa-f]+([eE]-?\\d*)?([pP][-+]\\d+)?",
+			"name": "constant.numeric.float.hexadecimal.lua"
+		},
+		{
+			"match": "(?<![\\w\\d.])0[xX][0-9A-Fa-f]+(?![pPeE.0-9])",
+			"name": "constant.numeric.integer.hexadecimal.lua"
+		},
+		{
+			"match": "(?<![\\w\\d.])\\d+(\\.\\d*)?([eE]-?\\d*)?",
+			"name": "constant.numeric.float.lua"
+		},
+		{
+			"match": "(?<![\\w\\d.])\\.\\d+([eE]-?\\d*)?",
+			"name": "constant.numeric.float.lua"
+		},
+		{
+			"match": "(?<![\\w\\d.])\\d+(?![pPeE.0-9])",
+			"name": "constant.numeric.integer.lua"
+		},
+		{
+			"include": "#string"
+		},
+		{
+			"captures": {
+				"1": {
+					"name": "punctuation.definition.comment.lua"
+				}
+			},
+			"match": "\\A(#!).*$\\n?",
+			"name": "comment.line.shebang.lua"
+		},
+		{
+			"include": "#comment"
+		},
+		{
+			"captures": {
+				"1": {
+					"name": "keyword.control.goto.lua"
+				},
+				"2": {
+					"name": "string.tag.lua"
+				}
+			},
+			"match": "\\b(goto)\\s+([a-zA-Z_][a-zA-Z0-9_]*)"
+		},
+		{
+			"captures": {
+				"1": {
+					"name": "punctuation.section.embedded.begin.lua"
+				},
+				"2": {
+					"name": "punctuation.section.embedded.end.lua"
+				}
+			},
+			"match": "(::)\\s*[a-zA-Z_][a-zA-Z0-9_]*\\s*(::)",
+			"name": "string.tag.lua"
+		},
+		{
+			"match": "<\\s*(const|close)\\s*>",
+			"captures": {
+				"1": {
+					"name": "string.tag.lua"
+				}
+			}
+		},
+		{
+			"match": "\\<[a-zA-Z_\\*][a-zA-Z0-9_\\.\\*\\-]*\\>",
+			"name": "storage.type.generic.lua"
+		},
+		{
+			"match": "\\b(break|do|else|for|if|elseif|goto|return|then|repeat|while|until|end|in)\\b",
+			"name": "keyword.control.lua"
+		},
+		{
+			"match": "\\b(local|global)\\b",
+			"name": "keyword.local.lua"
+		},
+		{
+			"match": "\\b(function)\\b(?![,:])",
+			"name": "keyword.control.lua"
+		},
+		{
+			"match": "(?<![^.]\\.|:)\\b(false|nil(?!:)|true|_ENV|_G|_VERSION|math\\.(pi|huge|maxinteger|mininteger)|utf8\\.charpattern|io\\.(stdin|stdout|stderr)|package\\.(config|cpath|loaded|loaders|path|preload|searchers))\\b|(?<![.])\\.{3}(?!\\.)",
+			"name": "constant.language.lua"
+		},
+		{
+			"match": "(?<![^.]\\.|:)\\b(self)\\b",
+			"name": "variable.language.self.lua"
+		},
+		{
+			"match": "(?<![^.]\\.|:)\\b(assert|collectgarbage|dofile|error|getfenv|getmetatable|ipairs|load|loadfile|loadstring|module|next|pairs|pcall|print|rawequal|rawget|rawlen|rawset|require|select|setfenv|setmetatable|tonumber|tostring|type|unpack|xpcall)\\b(?!\\s*=(?!=))",
+			"name": "support.function.lua"
+		},
+		{
+			"match": "(?<![^.]\\.|:)\\b(async)\\b(?!\\s*=(?!=))",
+			"name": "entity.name.tag.lua"
+		},
+		{
+			"match": "(?<![^.]\\.|:)\\b(coroutine\\.(create|isyieldable|close|resume|running|status|wrap|yield)|string\\.(byte|char|dump|find|format|gmatch|gsub|len|lower|match|pack|packsize|rep|reverse|sub|unpack|upper)|table\\.(concat|insert|maxn|move|pack|remove|sort|unpack)|math\\.(abs|acos|asin|atan2?|ceil|cosh?|deg|exp|floor|fmod|frexp|ldexp|log|log10|max|min|modf|pow|rad|random|randomseed|sinh?|sqrt|tanh?|tointeger|type)|io\\.(close|flush|input|lines|open|output|popen|read|tmpfile|type|write)|os\\.(clock|date|difftime|execute|exit|getenv|remove|rename|setlocale|time|tmpname)|package\\.(loadlib|seeall|searchpath)|debug\\.(debug|[gs]etfenv|[gs]ethook|getinfo|[gs]etlocal|[gs]etmetatable|getregistry|[gs]etupvalue|[gs]etuservalue|set[Cc]stacklimit|traceback|upvalueid|upvaluejoin)|bit32\\.(arshift|band|bnot|bor|btest|bxor|extract|replace|lrotate|lshift|rrotate|rshift)|utf8\\.(char|codes|codepoint|len|offset))\\b(?!\\s*=(?!=))",
+			"name": "support.function.library.lua"
+		},
+		{
+			"match": "\\b(and|or|not|\\|\\||\\&\\&|\\!)\\b",
+			"name": "keyword.operator.lua"
+		},
+		{
+			"match": "\\b([a-zA-Z_][a-zA-Z0-9_]*)\\b(?=\\s*(?:[({\"']|\\[\\[))",
+			"name": "support.function.any-method.lua"
+		},
+		{
+			"match": "\\b([a-zA-Z_][a-zA-Z0-9_]*)\\b(?=\\s*\\??:)",
+			"name": "entity.name.class.lua"
+		},
+		{
+			"match": "(?<=[^.]\\.|:)\\b([a-zA-Z_][a-zA-Z0-9_]*)\\b(?!\\s*=\\s*\\b(function)\\b)",
+			"name": "entity.other.attribute.lua"
+		},
+		{
+			"match": "\\b([a-zA-Z_][a-zA-Z0-9_]*)\\b(?!\\s*=\\s*\\b(function)\\b)",
+			"name": "variable.other.lua"
+		},
+		{
+			"match": "\\b([a-zA-Z_][a-zA-Z0-9_]*)\\b(?=\\s*=\\s*\\b(function)\\b)",
+			"name": "entity.name.function.lua"
+		},
+		{
+			"match": "\\+|-|%|#|\\*|\\/|\\^|==?|~=|!=|<=?|>=?|(?<!\\.)\\.{2}(?!\\.)",
+			"name": "keyword.operator.lua"
+		}
+	],
+	"repository": {
+		"escaped_char": {
+			"patterns": [
+				{
+					"match": "\\\\[abfnrtv\\\\\"'\\n]",
+					"name": "constant.character.escape.lua"
+				},
+				{
+					"match": "\\\\z[\\n\\t ]*",
+					"name": "constant.character.escape.lua"
+				},
+				{
+					"match": "\\\\\\d{1,3}",
+					"name": "constant.character.escape.byte.lua"
+				},
+				{
+					"match": "\\\\x[0-9A-Fa-f][0-9A-Fa-f]",
+					"name": "constant.character.escape.byte.lua"
+				},
+				{
+					"match": "\\\\u\\{[0-9A-Fa-f]+\\}",
+					"name": "constant.character.escape.unicode.lua"
+				},
+				{
+					"match": "\\\\.",
+					"name": "invalid.illegal.character.escape.lua"
+				}
+			]
+		},
+		"string": {
+			"patterns": [
+				{
+					"begin": "'",
+					"beginCaptures": {
+						"0": {
+							"name": "punctuation.definition.string.begin.lua"
+						}
+					},
+					"end": "'[ \\t]*|(?=\\n)",
+					"endCaptures": {
+						"0": {
+							"name": "punctuation.definition.string.end.lua"
+						}
+					},
+					"name": "string.quoted.single.lua",
+					"patterns": [
+						{
+							"include": "#escaped_char"
+						}
+					]
+				},
+				{
+					"begin": "\"",
+					"beginCaptures": {
+						"0": {
+							"name": "punctuation.definition.string.begin.lua"
+						}
+					},
+					"end": "\"[ \\t]*|(?=\\n)",
+					"endCaptures": {
+						"0": {
+							"name": "punctuation.definition.string.end.lua"
+						}
+					},
+					"name": "string.quoted.double.lua",
+					"patterns": [
+						{
+							"include": "#escaped_char"
+						}
+					]
+				},
+				{
+					"begin": "`",
+					"beginCaptures": {
+						"0": {
+							"name": "punctuation.definition.string.begin.lua"
+						}
+					},
+					"end": "`[ \\t]*|(?=\\n)",
+					"endCaptures": {
+						"0": {
+							"name": "punctuation.definition.string.end.lua"
+						}
+					},
+					"name": "string.quoted.double.lua"
+				},
+				{
+					"begin": "(?<=\\.cdef)\\s*(\\[(=*)\\[)",
+					"beginCaptures": {
+						"0": {
+							"name": "string.quoted.other.multiline.lua"
+						},
+						"1": {
+							"name": "punctuation.definition.string.begin.lua"
+						}
+					},
+					"contentName": "meta.embedded.lua",
+					"end": "(\\]\\2\\])[ \\t]*",
+					"endCaptures": {
+						"0": {
+							"name": "string.quoted.other.multiline.lua"
+						},
+						"1": {
+							"name": "punctuation.definition.string.end.lua"
+						}
+					},
+					"patterns": [
+						{
+							"include": "source.c"
+						}
+					]
+				},
+				{
+					"begin": "(?<!--)\\[(=*)\\[",
+					"beginCaptures": {
+						"0": {
+							"name": "punctuation.definition.string.begin.lua"
+						}
+					},
+					"end": "\\]\\1\\][ \\t]*",
+					"endCaptures": {
+						"0": {
+							"name": "punctuation.definition.string.end.lua"
+						}
+					},
+					"name": "string.quoted.other.multiline.lua"
+				}
+			]
+		},
+		"comment": {
+			"patterns": [
+				{
+					"begin": "(^[ \\t]+)?(?=--)",
+					"beginCaptures": {
+						"1": {
+							"name": "punctuation.whitespace.comment.leading.lua"
+						}
+					},
+					"end": "(?!\\G)((?!^)[ \\t]+\\n)?",
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.whitespace.comment.trailing.lua"
+						}
+					},
+					"patterns": [
+						{
+							"begin": "--\\[(=*)\\[",
+							"beginCaptures": {
+								"0": {
+									"name": "punctuation.definition.comment.begin.lua"
+								}
+							},
+							"end": "\\]\\1\\]",
+							"endCaptures": {
+								"0": {
+									"name": "punctuation.definition.comment.end.lua"
+								}
+							},
+							"name": "comment.block.lua",
+							"patterns": [
+								{
+									"include": "#comment_documentation_bracket"
+								}
+							]
+						},
+						{
+							"begin": "----",
+							"beginCaptures": {
+								"0": {
+									"name": "punctuation.definition.comment.lua"
+								}
+							},
+							"end": "\\n",
+							"name": "comment.line.double-dash.lua"
+						},
+						{
+							"begin": "---",
+							"beginCaptures": {
+								"0": {
+									"name": "punctuation.definition.comment.lua"
+								}
+							},
+							"end": "\\n",
+							"name": "comment.line.double-dash.documentation.lua",
+							"patterns": [
+								{
+									"include": "#emmydoc"
+								},
+								{
+									"include": "#ldoc_summary"
+								},
+								{
+									"include": "#ldoc_tag"
+								}
+							]
+						},
+						{
+							"begin": "--",
+							"beginCaptures": {
+								"0": {
+									"name": "punctuation.definition.comment.lua"
+								}
+							},
+							"end": "\\n",
+							"name": "comment.line.double-dash.lua",
+							"patterns": [
+								{
+									"include": "#ldoc_tag"
+								}
+							]
+						}
+					]
+				},
+				{
+					"begin": "\\/\\*",
+					"beginCaptures": {
+						"0": {
+							"name": "punctuation.definition.comment.begin.lua"
+						}
+					},
+					"end": "\\*\\/",
+					"endCaptures": {
+						"0": {
+							"name": "punctuation.definition.comment.end.lua"
+						}
+					},
+					"name": "comment.block.lua",
+					"patterns": [
+						{
+							"include": "#comment_documentation_asterisk"
+						}
+					]
+				}
+			]
+		},
+		"comment_documentation_asterisk": {
+			"begin": "(?<=/\\*\\*)([^*]|\\*(?!/))*$",
+			" ": "(^|\\G)[ \\t]*\\*(?!/)(?=([^*]|[*](?!/))*$)",
+			"patterns": [
+				{
+					"include": "#emmydoc"
+				},
+				{
+					"include": "#ldoc_tag"
+				}
+			]
+		},
+		"comment_documentation_bracket": {
+			"begin": "(?<=--\\[\\[)([^-]|\\-(?!\\]\\]))*$",
+			"while": "(^|\\G)[ \\t]*-*(?!\\]\\])(?=([^-]|[-](?!\\]\\]))*$)",
+			"patterns": [
+				{
+					"include": "#emmydoc"
+				},
+				{
+					"include": "#ldoc_tag"
+				}
+			]
+		},
+		"emmydoc": {
+			"patterns": [
+				{
+					"begin": "(?<=---[ \\t]*)@class",
+					"beginCaptures": {
+						"0": {
+							"name": "storage.type.annotation.lua"
+						}
+					},
+					"end": "(?=[\\n@#])",
+					"patterns": [
+						{
+							"match": "\\b([a-zA-Z_\\*][a-zA-Z0-9_\\.\\*\\-]*)",
+							"name": "support.class.lua"
+						},
+						{
+							"match": ":|,",
+							"name": "keyword.operator.lua"
+						}
+					]
+				},
+				{
+					"begin": "(?<=---[ \\t]*)@enum",
+					"beginCaptures": {
+						"0": {
+							"name": "storage.type.annotation.lua"
+						}
+					},
+					"end": "(?=[\\n@#])",
+					"patterns": [
+						{
+							"begin": "\\b([a-zA-Z_\\*][a-zA-Z0-9_\\.\\*\\-]*)",
+							"beginCaptures": {
+								"0": {
+									"name": "variable.lua"
+								}
+							},
+							"end": "(?=\\n)"
+						}
+					]
+				},
+				{
+					"begin": "(?<=---[ \\t]*)@type",
+					"beginCaptures": {
+						"0": {
+							"name": "storage.type.annotation.lua"
+						}
+					},
+					"end": "(?=[\\n@#])",
+					"patterns": [
+						{
+							"include": "#emmydoc.type"
+						}
+					]
+				},
+				{
+					"begin": "(?<=---[ \\t]*)@alias",
+					"beginCaptures": {
+						"0": {
+							"name": "storage.type.annotation.lua"
+						}
+					},
+					"end": "(?=[\\n@#])",
+					"patterns": [
+						{
+							"begin": "\\b([a-zA-Z_\\*][a-zA-Z0-9_\\.\\*\\-]*)",
+							"beginCaptures": {
+								"0": {
+									"name": "variable.lua"
+								}
+							},
+							"end": "(?=[\\n#])",
+							"patterns": [
+								{
+									"include": "#emmydoc.type"
+								}
+							]
+						}
+					]
+				},
+				{
+					"begin": "(?<=---[ \\t]*)(@operator)\\s*(\\b[a-z]+)?",
+					"beginCaptures": {
+						"1": {
+							"name": "storage.type.annotation.lua"
+						},
+						"2": {
+							"name": "support.function.library.lua"
+						}
+					},
+					"end": "(?=[\\n@#])",
+					"patterns": [
+						{
+							"include": "#emmydoc.type"
+						}
+					]
+				},
+				{
+					"begin": "(?<=---[ \\t]*)@cast",
+					"beginCaptures": {
+						"0": {
+							"name": "storage.type.annotation.lua"
+						}
+					},
+					"end": "(?=[\\n@#])",
+					"patterns": [
+						{
+							"begin": "\\b([a-zA-Z_\\*][a-zA-Z0-9_\\.\\*\\-]*)",
+							"beginCaptures": {
+								"0": {
+									"name": "variable.other.lua"
+								}
+							},
+							"end": "(?=\\n)",
+							"patterns": [
+								{
+									"include": "#emmydoc.type"
+								},
+								{
+									"match": "([+-|])",
+									"name": "keyword.operator.lua"
+								}
+							]
+						}
+					]
+				},
+				{
+					"begin": "(?<=---[ \\t]*)@param",
+					"beginCaptures": {
+						"0": {
+							"name": "storage.type.annotation.lua"
+						}
+					},
+					"end": "(?=[\\n@#])",
+					"patterns": [
+						{
+							"begin": "\\b([a-zA-Z_][a-zA-Z0-9_]*)\\b(\\??)",
+							"beginCaptures": {
+								"1": {
+									"name": "entity.name.variable.lua"
+								},
+								"2": {
+									"name": "keyword.operator.lua"
+								}
+							},
+							"end": "(?=[\\n#])",
+							"patterns": [
+								{
+									"include": "#emmydoc.type"
+								}
+							]
+						}
+					]
+				},
+				{
+					"begin": "(?<=---[ \\t]*)@return",
+					"beginCaptures": {
+						"0": {
+							"name": "storage.type.annotation.lua"
+						}
+					},
+					"end": "(?=[\\n@#])",
+					"patterns": [
+						{
+							"match": "\\?",
+							"name": "keyword.operator.lua"
+						},
+						{
+							"include": "#emmydoc.type"
+						}
+					]
+				},
+				{
+					"begin": "(?<=---[ \\t]*)@field",
+					"beginCaptures": {
+						"0": {
+							"name": "storage.type.annotation.lua"
+						}
+					},
+					"end": "(?=[\\n@#])",
+					"patterns": [
+						{
+							"begin": "(\\b([a-zA-Z_][a-zA-Z0-9_]*)\\b|(\\[))(\\??)",
+							"beginCaptures": {
+								"2": {
+									"name": "entity.name.variable.lua"
+								},
+								"3": {
+									"name": "keyword.operator.lua"
+								}
+							},
+							"end": "(?=[\\n#])",
+							"patterns": [
+								{
+									"include": "#string"
+								},
+								{
+									"include": "#emmydoc.type"
+								},
+								{
+									"match": "\\]",
+									"name": "keyword.operator.lua"
+								}
+							]
+						}
+					]
+				},
+				{
+					"begin": "(?<=---[ \\t]*)@generic",
+					"beginCaptures": {
+						"0": {
+							"name": "storage.type.annotation.lua"
+						}
+					},
+					"end": "(?=[\\n@#])",
+					"patterns": [
+						{
+							"begin": "\\b([a-zA-Z_][a-zA-Z0-9_]*)\\b",
+							"beginCaptures": {
+								"0": {
+									"name": "storage.type.generic.lua"
+								}
+							},
+							"end": "(?=\\n)|(,)",
+							"endCaptures": {
+								"0": {
+									"name": "keyword.operator.lua"
+								}
+							},
+							"patterns": [
+								{
+									"match": ":",
+									"name": "keyword.operator.lua"
+								},
+								{
+									"include": "#emmydoc.type"
+								}
+							]
+						}
+					]
+				},
+				{
+					"begin": "(?<=---[ \\t]*)@vararg",
+					"beginCaptures": {
+						"0": {
+							"name": "storage.type.annotation.lua"
+						}
+					},
+					"end": "(?=[\\n@#])",
+					"patterns": [
+						{
+							"include": "#emmydoc.type"
+						}
+					]
+				},
+				{
+					"begin": "(?<=---[ \\t]*)@overload",
+					"beginCaptures": {
+						"0": {
+							"name": "storage.type.annotation.lua"
+						}
+					},
+					"end": "(?=[\\n@#])",
+					"patterns": [
+						{
+							"include": "#emmydoc.type"
+						}
+					]
+				},
+				{
+					"begin": "(?<=---[ \\t]*)@deprecated",
+					"beginCaptures": {
+						"0": {
+							"name": "storage.type.annotation.lua"
+						}
+					},
+					"end": "(?=[\\n@#])"
+				},
+				{
+					"begin": "(?<=---[ \\t]*)@meta",
+					"beginCaptures": {
+						"0": {
+							"name": "storage.type.annotation.lua"
+						}
+					},
+					"end": "(?=[\\n@#])"
+				},
+				{
+					"begin": "(?<=---[ \\t]*)@private",
+					"beginCaptures": {
+						"0": {
+							"name": "storage.type.annotation.lua"
+						}
+					},
+					"end": "(?=[\\n@#])"
+				},
+				{
+					"begin": "(?<=---[ \\t]*)@protected",
+					"beginCaptures": {
+						"0": {
+							"name": "storage.type.annotation.lua"
+						}
+					},
+					"end": "(?=[\\n@#])"
+				},
+				{
+					"begin": "(?<=---[ \\t]*)@package",
+					"beginCaptures": {
+						"0": {
+							"name": "storage.type.annotation.lua"
+						}
+					},
+					"end": "(?=[\\n@#])"
+				},
+				{
+					"begin": "(?<=---[ \\t]*)@version",
+					"beginCaptures": {
+						"0": {
+							"name": "storage.type.annotation.lua"
+						}
+					},
+					"end": "(?=[\\n@#])",
+					"patterns": [
+						{
+							"match": "\\b(5\\.1|5\\.2|5\\.3|5\\.4|JIT)\\b",
+							"name": "support.class.lua"
+						},
+						{
+							"match": ",|\\>|\\<",
+							"name": "keyword.operator.lua"
+						}
+					]
+				},
+				{
+					"begin": "(?<=---[ \\t]*)@see",
+					"beginCaptures": {
+						"0": {
+							"name": "storage.type.annotation.lua"
+						}
+					},
+					"end": "(?=[\\n@#])",
+					"patterns": [
+						{
+							"match": "\\b([a-zA-Z_\\*][a-zA-Z0-9_\\.\\*\\-]*)",
+							"name": "support.class.lua"
+						},
+						{
+							"match": "#",
+							"name": "keyword.operator.lua"
+						}
+					]
+				},
+				{
+					"begin": "(?<=---[ \\t]*)@diagnostic",
+					"beginCaptures": {
+						"0": {
+							"name": "storage.type.annotation.lua"
+						}
+					},
+					"end": "(?=[\\n@#])",
+					"patterns": [
+						{
+							"begin": "([a-zA-Z_\\-0-9]+)[ \\t]*(:)?",
+							"beginCaptures": {
+								"1": {
+									"name": "keyword.other.unit"
+								},
+								"2": {
+									"name": "keyword.operator.unit"
+								}
+							},
+							"end": "(?=\\n)",
+							"patterns": [
+								{
+									"match": "\\b([a-zA-Z_\\*][a-zA-Z0-9_\\-]*)",
+									"name": "support.class.lua"
+								},
+								{
+									"match": ",",
+									"name": "keyword.operator.lua"
+								}
+							]
+						}
+					]
+				},
+				{
+					"begin": "(?<=---[ \\t]*)@module",
+					"beginCaptures": {
+						"0": {
+							"name": "storage.type.annotation.lua"
+						}
+					},
+					"end": "(?=[\\n@#])",
+					"patterns": [
+						{
+							"include": "#string"
+						}
+					]
+				},
+				{
+					"match": "(?<=---[ \\t]*)@(async|nodiscard)",
+					"name": "storage.type.annotation.lua"
+				},
+				{
+					"begin": "(?<=---)\\|\\s*[\\>\\+]?",
+					"beginCaptures": {
+						"0": {
+							"name": "storage.type.annotation.lua"
+						}
+					},
+					"end": "(?=[\\n@#])",
+					"patterns": [
+						{
+							"include": "#string"
+						}
+					]
+				}
+			]
+		},
+		"emmydoc.type": {
+			"patterns": [
+				{
+					"begin": "\\bfun\\b",
+					"beginCaptures": {
+						"0": {
+							"name": "keyword.control.lua"
+						}
+					},
+					"end": "(?=[\\s#])",
+					"patterns": [
+						{
+							"match": "[\\(\\),:\\?][ \\t]*",
+							"name": "keyword.operator.lua"
+						},
+						{
+							"match": "([a-zA-Z_][a-zA-Z0-9_\\.\\*\\[\\]\\<\\>\\,\\-]*)(?<!,)[ \\t]*(?=\\??:)",
+							"name": "entity.name.variable.lua"
+						},
+						{
+							"include": "#emmydoc.type"
+						},
+						{
+							"include": "#string"
+						}
+					]
+				},
+				{
+					"match": "\\<[a-zA-Z_\\*][a-zA-Z0-9_\\.\\*\\-]*\\>",
+					"name": "storage.type.generic.lua"
+				},
+				{
+					"match": "\\basync\\b",
+					"name": "entity.name.tag.lua"
+				},
+				{
+					"match": "[\\{\\}\\:\\,\\?\\|\\`][ \\t]*",
+					"name": "keyword.operator.lua"
+				},
+				{
+					"begin": "(?=[a-zA-Z_\\.\\*\"'\\[])",
+					"end": "(?=[\\s\\)\\,\\?\\:\\}\\|#])",
+					"patterns": [
+						{
+							"match": "([a-zA-Z0-9_\\.\\*\\[\\]\\<\\>\\,\\-]+)(?<!,)[ \\t]*",
+							"name": "support.type.lua"
+						},
+						{
+							"match": "(\\.\\.\\.)[ \\t]*",
+							"name": "constant.language.lua"
+						},
+						{
+							"include": "#string"
+						}
+					]
+				}
+			]
+		},
+		"ldoc_tag": {
+			"match": "\\G[ \\t]*(@)(alias|annotation|author|charset|class|classmod|comment|constructor|copyright|description|example|export|factory|field|file|fixme|function|include|lfunction|license|local|module|name|param|pragma|private|raise|release|return|script|section|see|set|static|submodule|summary|tfield|thread|tparam|treturn|todo|topic|type|usage|warning|within)\\b",
+			"end": "(?!@)\\b",
+			"captures": {
+				"1": {
+					"name": "punctuation.definition.block.tag.ldoc"
+				},
+				"2": {
+					"name": "storage.type.class.ldoc"
+				}
+			}
+		},
+		"ldoc_summary": {
+			"begin": "\\G ?(?!@\\w+| )",
+			"beginCaptures": {
+				"0": {
+					"name": "punctuation.definition.comment.lua"
+				}
+			},
+			"end": "$",
+			"name": "entity.name.section.ldoc"
+		}
+	}
 }


### PR DESCRIPTION
*   [x] `@` tags inside of block comments
*   [x] `--` tag prefix as well as `---`
*   [x] redundant `-{1,4}` prefix support in block comment
*   [x] stretch goal - highlight tagless `---` as LDoc summary/header (likely requiring LSP)