### PR TITLE
Added compatibility for --]] to end block comment

### DIFF
--- a/Syntaxes/Lua.plist
+++ b/Syntaxes/Lua.plist
@@ -555,7 +555,7 @@
                   </dict>
                 </dict>
                 <key>end</key>
-                <string>\]\1\]</string>
+                <string>(--)?\]\1\]</string>
                 <key>endCaptures</key>
                 <dict>
                   <key>0</key>
@@ -586,7 +586,7 @@
                   </dict>
                 </dict>
                 <key>end</key>
-                <string>\]\1\]</string>
+                <string>(--)?\]\1\]</string>
                 <key>endCaptures</key>
                 <dict>
                   <key>0</key>

--- a/lua.tmLanguage.json
+++ b/lua.tmLanguage.json
@@ -357,7 +357,7 @@
 									"name": "punctuation.definition.comment.begin.lua"
 								}
 							},
-							"end": "\\]\\1\\]",
+							"end": "(--)?\\]\\1\\]",
 							"endCaptures": {
 								"0": {
 									"name": "punctuation.definition.comment.end.lua"
@@ -377,7 +377,7 @@
 									"name": "punctuation.definition.comment.begin.lua"
 								}
 							},
-							"end": "\\]\\1\\]",
+							"end": "(--)?\\]\\1\\]",
 							"endCaptures": {
 								"0": {
 									"name": "punctuation.definition.comment.end.lua"


### PR DESCRIPTION
Fixes #20 , where --]] is not accepted as a valid way to end a block comment