### PR TITLE
Allow parentheses around ffi.cdef expressions

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,7 +11,7 @@
             "skipFiles": [
                 "<node_internals>/**"
             ],
-            "program": "${workspaceFolder}\\build\\build.js",
+            "program": "${workspaceFolder}/build/build.js",
             "outFiles": [
                 "${workspaceFolder}/**/*.js"
             ]

--- a/Syntaxes/Lua.plist
+++ b/Syntaxes/Lua.plist
@@ -451,7 +451,7 @@
           </dict>
           <dict>
             <key>begin</key>
-            <string>(?&lt;=\.cdef)\s*(\[(=*)\[)</string>
+            <string>(?&lt;=\.cdef)\s*(\(?\[(=*)\[)</string>
             <key>beginCaptures</key>
             <dict>
               <key>0</key>
@@ -468,7 +468,7 @@
             <key>contentName</key>
             <string>meta.embedded.lua</string>
             <key>end</key>
-            <string>(\]\2\])[ \t]*</string>
+            <string>(\]\2\]\)?)[ \t]*</string>
             <key>endCaptures</key>
             <dict>
               <key>0</key>

--- a/lua.tmLanguage.json
+++ b/lua.tmLanguage.json
@@ -292,7 +292,7 @@
 					"name": "string.quoted.double.lua"
 				},
 				{
-					"begin": "(?<=\\.cdef)\\s*(\\[(=*)\\[)",
+					"begin": "(?<=\\.cdef)\\s*(\\(?\\[(=*)\\[)",
 					"beginCaptures": {
 						"0": {
 							"name": "string.quoted.other.multiline.lua"
@@ -302,7 +302,7 @@
 						}
 					},
 					"contentName": "meta.embedded.lua",
-					"end": "(\\]\\2\\])[ \\t]*",
+					"end": "(\\]\\2\\]\\)?)[ \\t]*",
 					"endCaptures": {
 						"0": {
 							"name": "string.quoted.other.multiline.lua"


### PR DESCRIPTION
## Problem

The highlighter has really convenient support for embedded C code when it sees the `ffi.cdef [[ ... ]` pattern, but some codebase styles ([including the default in stylua](https://github.com/JohnnyMorganz/StyLua?tab=readme-ov-file#configuring-runtime-syntax-selection)), enforce parentheses around the multiline string which causes the rule to not match.

![broken highlighting](https://github.com/user-attachments/assets/37bbd880-191e-4720-abb6-666ff30c4866)

![working highlighting](https://github.com/user-attachments/assets/3695791c-cc6c-40b3-b62f-19ee6fcfbe59)

## Solution

Tweak the regexps to allow optional parentheses around the multiline string.

