### PR TITLE
Differentiate between word/symbol logical operators

### DIFF
--- a/lua.tmLanguage.json
+++ b/lua.tmLanguage.json
@@ -182,7 +182,7 @@
 		},
 		{
 			"match": "\\b(and|or|not)\\b",
-			"name": "keyword.operator.lua.logical"
+			"name": "keyword.operator.logical.lua"
 		},
 		{
 			"match": "\\b([a-zA-Z_][a-zA-Z0-9_]*)\\b(?=\\s*(?:[({\"']|\\[\\[))",

--- a/lua.tmLanguage.json
+++ b/lua.tmLanguage.json
@@ -177,8 +177,12 @@
 			"name": "support.function.library.lua"
 		},
 		{
-			"match": "\\b(and|or|not|\\|\\||\\&\\&|\\!)\\b",
+			"match": "\\b(\\|\\||\\&\\&|\\!)\\b",
 			"name": "keyword.operator.lua"
+		},
+		{
+			"match": "\\b(and|or|not)\\b",
+			"name": "keyword.operator.lua.logical"
 		},
 		{
 			"match": "\\b([a-zA-Z_][a-zA-Z0-9_]*)\\b(?=\\s*(?:[({\"']|\\[\\[))",


### PR DESCRIPTION
Allows differentiation between `and, or, not` and `&&, ||, !`.  
This helps address [microsoft/vscode#71504](https://github.com/microsoft/vscode/issues/71504).